### PR TITLE
[Fix] 산책 완료 클릭시 Center 값 미적용 수정

### DIFF
--- a/src/app/log/record/LogRecord.view.tsx
+++ b/src/app/log/record/LogRecord.view.tsx
@@ -62,6 +62,7 @@ const LogRecordView = ({
         isShowCenterMarker={pageStep !== "LOG_RECORD_EDITING"}
         onClickPin={onClickPin}
         selectedPinIndex={currentPinIndex}
+        mapHeight={pageStep === "LOG_RECORD_EDITING" ? "50%" : "100%"}
       />
 
       <S.LogRecordTop>

--- a/src/components/MasilMap/MasilMap.style.module.css
+++ b/src/components/MasilMap/MasilMap.style.module.css
@@ -1,7 +1,4 @@
 .masil__map {
-  width: 100%;
-  flex-grow: 1;
-
   position: relative;
 
   z-index: 0;

--- a/src/components/MasilMap/MasilMap.style.module.css
+++ b/src/components/MasilMap/MasilMap.style.module.css
@@ -1,5 +1,0 @@
-.masil__map {
-  position: relative;
-
-  z-index: 0;
-}

--- a/src/components/MasilMap/MasilMap.tsx
+++ b/src/components/MasilMap/MasilMap.tsx
@@ -1,5 +1,3 @@
-import style from "./MasilMap.style.module.css";
-
 import { GeoPosition, Pin } from "@/types/OriginDataType";
 import { Map } from "react-kakao-maps-sdk";
 import CenterMarker from "./components/CenterMarker/CenterMarker";
@@ -101,6 +99,7 @@ const MasilMap = ({
 }: MasilMapProps) => {
   const [outCenterPosition, setOutCenterPosition] = useState<GeoPosition>({ lat: 0, lng: 0 });
   const { isOutCenter, setIsOutCenter } = useMapCenterStore();
+  const mapRef = useRef<kakao.maps.Map | null>(null);
 
   /**
    * @summary drag, zoom으로 인해 벗어난 Map의 center를 일정 시간 후 강제로 다시 이동시킵니다.
@@ -134,28 +133,29 @@ const MasilMap = ({
     }, 200),
   ).current;
 
-  const mapRef = useRef<kakao.maps.Map | null>(null);
-
   useEffect(() => {
     const { current } = mapRef;
 
     if (current) {
       current.relayout();
     }
-  }, [mapHeight]);
+  }, [mapHeight, mapWidth]);
 
   return (
     <Map
       ref={mapRef}
       center={isOutCenter ? outCenterPosition : center}
-      className={style.masil__map}
       draggable={draggable}
       zoomable={zoomable}
       minLevel={minZoomLevel && minZoomLevel}
       maxLevel={maxZoomLevel && maxZoomLevel}
-      onDrag={handleMap}
-      onZoomChanged={handleMap}
-      style={{ width: mapWidth, height: mapHeight }}
+      onCenterChanged={handleMap}
+      style={{
+        width: mapWidth,
+        height: mapHeight,
+        zIndex: 0,
+        position: "relative",
+      }}
     >
       {isShowCenterMarker && (
         <CenterMarker

--- a/src/components/MasilMap/MasilMap.tsx
+++ b/src/components/MasilMap/MasilMap.tsx
@@ -17,6 +17,9 @@ interface MasilMapProps {
   path: GeoPosition[];
   pins: Pin[];
 
+  mapWidth?: string;
+  mapHeight?: string;
+
   draggable?: boolean;
   zoomable?: boolean;
   minZoomLevel?: number;
@@ -71,6 +74,9 @@ const MasilMap = ({
   center,
   path,
   pins,
+
+  mapHeight = "100%",
+  mapWidth = "100%",
 
   draggable = true,
   zoomable = true,
@@ -136,7 +142,7 @@ const MasilMap = ({
     if (current) {
       current.relayout();
     }
-  }, []);
+  }, [mapHeight]);
 
   return (
     <Map
@@ -149,6 +155,7 @@ const MasilMap = ({
       maxLevel={maxZoomLevel && maxZoomLevel}
       onDrag={handleMap}
       onZoomChanged={handleMap}
+      style={{ width: mapWidth, height: mapHeight }}
     >
       {isShowCenterMarker && (
         <CenterMarker

--- a/src/components/MasilMap/MasilMap.tsx
+++ b/src/components/MasilMap/MasilMap.tsx
@@ -128,8 +128,11 @@ const MasilMap = ({
     }, 200),
   ).current;
 
+  const mapRef = useRef<kakao.maps.Map | null>(null);
+
   return (
     <Map
+      ref={mapRef}
       center={isOutCenter ? outCenterPosition : center}
       className={style.masil__map}
       draggable={draggable}

--- a/src/components/MasilMap/MasilMap.tsx
+++ b/src/components/MasilMap/MasilMap.tsx
@@ -9,7 +9,7 @@ import CustomPin from "./components/CustomPin/CustomPin";
 import Theme from "@/styles/theme";
 
 import { debounce, throttle } from "lodash";
-import { useRef, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import useMapCenterStore from "./store/useMapCenterStore";
 
 interface MasilMapProps {
@@ -129,6 +129,14 @@ const MasilMap = ({
   ).current;
 
   const mapRef = useRef<kakao.maps.Map | null>(null);
+
+  useEffect(() => {
+    const { current } = mapRef;
+
+    if (current) {
+      current.relayout();
+    }
+  }, []);
 
   return (
     <Map


### PR DESCRIPTION
## 🔗 이슈 링크

- #84 

close #84  


## 💡 예상 원인과 해결 방법
- kakao Map 라이브러리에서 사용하는 Map 자체에 center 값에 대한 별도의 state가 존재하는것으로 예상되어집니다.

- 이로 인해 window ( browser ) 의 리사이징되거나
- 혹은 현재 저희가 Map에게 제공하고 있는 useLocation 이라는 state가 변경되지 않은 채로, 드래그 혹은 zoom 외의 방법( 별도의 방법으로 Map의 크기가 줄어드는 등 ..  )으로 Map 요소의 크기가 변경되었을때 Center가 원활하게 이동하지 않는 것으로 확인하였습니다.

이를 해결하기 위한 방법으로 
- kakao Map API 에서 제공되어지는 relayout 메서드를 통해 Map 요소 자체의 사이즈가 변경되었을때 실행되어 layout 크기를 다시 파악할 수 있도록 변경하였습니다.
  - 추가로 Map 요소의 사이즈를 감지할 수 있도록 기존 flex-grow 속성을 통해 관리하던 Map의 height 값을 MasilMap Component의 props로 전달받아 적용될 수 있도록 변경하였습니다.

- Map에서의미하는 Map 기준의 center가 변경되어지는 모든 행동에 대해 2초뒤 저희가 전달하는 useLocation 값으로 돌아올 수 있도록 구현하였습니다.
  - onCenterChange 속성을 이용하는 방법으로 기존 드래그, 줌을 허용하는 방법은 동일하게 유지되었습니다. 


## ➕ 추가 작업 사항
style 파일이 의미 없다 생각되어 제거하고 기존 style 속성은 Map 컴포넌트의  속성에 전달하는 방법을 통해 대체하였습니다.


## 🤔 테스트 및 검증 && 고민 사항
<!-- 배포에서 체크해봐야 할 부분 -->
<!-- 궁금한 점, 팀원들의 의견이 필요한 부분, 크로스체크가 필요한 부분 등 -->
- 


## 💬 피드백 반영사항
<!-- 피드백 요청 사항을 리스트로 표시하고 반영 여부를 표시합니다 -->
- 
