### PR TITLE
[Feat] UserEdit 닉네임 , 성별 input 구현

### DIFF
--- a/src/app/signin/SignIn.constants.ts
+++ b/src/app/signin/SignIn.constants.ts
@@ -7,39 +7,3 @@ export const SEX_OPTIONS: SexOptionProps[] = [
   { label: "남성", value: "male" },
   { label: "여성", value: "female" },
 ];
-
-export const signInValidation = {
-  birthDate: {
-    required: "나이는 필수 항목입니다.",
-    min: {
-      value: 14,
-      message: "14세 이상이어야 합니다",
-    },
-    max: {
-      value: 100,
-      message: "100세 이하여야 합니다",
-    },
-  },
-  height: {
-    required: "키는 필수 항목입니다.",
-    min: {
-      value: 50,
-      message: "값이 너무 작습니다.",
-    },
-    max: {
-      value: 500,
-      message: "값이 너무 큽니다.",
-    },
-  },
-  weight: {
-    required: "체중은 필수 항목입니다.",
-    min: {
-      value: 10,
-      message: "값이 너무 작습니다.",
-    },
-    max: {
-      value: 500,
-      message: "값이 너무 큽니다.",
-    },
-  },
-};

--- a/src/app/signin/SignIn.constants.ts
+++ b/src/app/signin/SignIn.constants.ts
@@ -1,9 +1,0 @@
-export interface SexOptionProps {
-  label: string;
-  value: "male" | "female";
-}
-
-export const SEX_OPTIONS: SexOptionProps[] = [
-  { label: "남성", value: "male" },
-  { label: "여성", value: "female" },
-];

--- a/src/app/signin/SignIn.controller.tsx
+++ b/src/app/signin/SignIn.controller.tsx
@@ -9,6 +9,7 @@ import { SignInStep1, SignInStep2, SignInStep3, SignInStep4 } from "./sections";
 import { TopNavigator } from "@/components/navigators/TopNavigator";
 import { GoBackButton, StepSkipButton } from "@/components/navigators/TopNavigator/components";
 import { useRouter } from "next/navigation";
+import { IntensityOption } from "@/types/OriginDataType";
 
 export interface SignInFormProps {
   nickname: string;
@@ -16,7 +17,7 @@ export interface SignInFormProps {
   birthDate?: number;
   height?: number;
   weight?: number;
-  exerciseIntensity?: "SUPER_LOW" | "LOW" | "MIDDLE" | "HIGH" | "SUPER_HIGH";
+  exerciseIntensity?: IntensityOption;
   policy_personal: boolean;
   policy_location: boolean;
   policy_age: boolean;

--- a/src/app/signin/sections/SignInStep1.tsx
+++ b/src/app/signin/sections/SignInStep1.tsx
@@ -5,6 +5,7 @@ import useTheme from "@/lib/hooks/useTheme";
 
 import { Button, Input, InputLabel } from "@/components";
 import { SignInFormProps } from "../SignIn.controller";
+import { validation_user } from "@/constants/userValidate";
 
 interface SignInStep1Props {
   register: UseFormRegister<SignInFormProps>;
@@ -20,13 +21,7 @@ const SignInStep1 = ({ register, errors }: SignInStep1Props) => {
         <div className="relative flex-1 space-y-2">
           <Input
             required
-            register={register("nickname", {
-              required: "NickName is required",
-              minLength: {
-                message: "NickName Should be longer then 2 chars",
-                value: 2,
-              },
-            })}
+            register={register("nickname", validation_user.nickname)}
             placeholder="닉네임을 입력해주세요."
             style={{
               fontSize: "1.5rem",

--- a/src/app/signin/sections/SignInStep2.tsx
+++ b/src/app/signin/sections/SignInStep2.tsx
@@ -70,7 +70,7 @@ const SignInStep2 = ({ setValue, register, errors }: SignInStep2Props) => {
   const birthDateInput = createInput({
     register,
     name: "birthDate",
-    validation: validation_user.birthDay,
+    validation: validation_user.birthDate,
     placeholder: "만 나이를 입력해주세요.",
   });
   const heightInput = createInput({

--- a/src/app/signin/sections/SignInStep2.tsx
+++ b/src/app/signin/sections/SignInStep2.tsx
@@ -8,9 +8,9 @@ import useTheme from "@/lib/hooks/useTheme";
 import { Button, Input, InputLabel } from "@/components";
 import { SignInFormProps } from "../SignIn.controller";
 import useSignInModel from "../SignIn.model";
-import { SEX_OPTIONS } from "../SignIn.constants";
 import * as S from "../SignIn.styles";
 import { validation_user } from "@/constants/userValidate";
+import { SEX_OPTIONS } from "@/constants/variable";
 
 interface SignInStep2Props {
   setValue: UseFormSetValue<SignInFormProps>;

--- a/src/app/signin/sections/SignInStep2.tsx
+++ b/src/app/signin/sections/SignInStep2.tsx
@@ -8,8 +8,9 @@ import useTheme from "@/lib/hooks/useTheme";
 import { Button, Input, InputLabel } from "@/components";
 import { SignInFormProps } from "../SignIn.controller";
 import useSignInModel from "../SignIn.model";
-import { SEX_OPTIONS, signInValidation } from "../SignIn.constants";
+import { SEX_OPTIONS } from "../SignIn.constants";
 import * as S from "../SignIn.styles";
+import { validation_user } from "@/constants/userValidate";
 
 interface SignInStep2Props {
   setValue: UseFormSetValue<SignInFormProps>;
@@ -69,20 +70,20 @@ const SignInStep2 = ({ setValue, register, errors }: SignInStep2Props) => {
   const birthDateInput = createInput({
     register,
     name: "birthDate",
-    validation: signInValidation.birthDate,
+    validation: validation_user.birthDay,
     placeholder: "만 나이를 입력해주세요.",
   });
   const heightInput = createInput({
     register,
     name: "height",
-    validation: signInValidation.height,
+    validation: validation_user.height,
     placeholder: "키를 입력해주세요.",
     unit: "cm",
   });
   const weightInput = createInput({
     register,
     name: "weight",
-    validation: signInValidation.weight,
+    validation: validation_user.weight,
     placeholder: "체중을 입력해주세요.",
     unit: "kg",
   });

--- a/src/app/signin/sections/SignInStep3.tsx
+++ b/src/app/signin/sections/SignInStep3.tsx
@@ -7,19 +7,12 @@ import useTheme from "@/lib/hooks/useTheme";
 
 import { SignInFormProps } from "../SignIn.controller";
 import * as S from "../SignIn.styles";
+import { INTENSITY_OPTIONS } from "@/constants/variable";
 
 interface SignInStep3Props {
   setValue: UseFormSetValue<SignInFormProps>;
   getValues: UseFormGetValues<SignInFormProps>;
 }
-
-const exerciseIntensity = [
-  { label: "좌식", value: "SUPER_LOW" },
-  { label: "가벼운 활동(가벼운 운동/스포츠 3-5일/주)", value: "LOW" },
-  { label: "적당히 활동적(중간 정도의 운동/스포츠 3-5일/주)", value: "MIDDLE" },
-  { label: "활동적(일주일에 6-7일 격렬한 운동/스포츠)", value: "HIGH" },
-  { label: "매우 활독적인 경우 (매우 힘든 운동/스포츠 및 육체 노동)", value: "SUPER_HIGH" },
-];
 
 const SignInStep3 = ({ getValues, setValue }: SignInStep3Props) => {
   const theme = useTheme();
@@ -35,7 +28,7 @@ const SignInStep3 = ({ getValues, setValue }: SignInStep3Props) => {
         <S.Title style={{ marginBottom: "1.2rem" }}>평소 운동 강도</S.Title>
         기초 대사량 계산에 필요한 활동 계수를 설정해요.
       </S.ExerciseIntensityTitleSection>
-      {exerciseIntensity.map((option, index) => (
+      {INTENSITY_OPTIONS.map((option, index) => (
         <S.ExerciseIntensityOption key={index}>
           <Button
             id={option.value}

--- a/src/app/user/[id]/setting/UserSetting.controller.tsx
+++ b/src/app/user/[id]/setting/UserSetting.controller.tsx
@@ -1,5 +1,15 @@
+import { TopNavigator } from "@/components/navigators/TopNavigator";
 import UserSettingView from "./UserSetting.view";
+import { GoBackButton } from "@/components/navigators/TopNavigator/components";
 
 export const UserSettingController = () => {
-  return <UserSettingView />;
+  return (
+    <>
+      <TopNavigator
+        leftChildren={<GoBackButton />}
+        title={"설정"}
+      />
+      <UserSettingView />
+    </>
+  );
 };

--- a/src/app/user/[id]/setting/UserSetting.view.tsx
+++ b/src/app/user/[id]/setting/UserSetting.view.tsx
@@ -3,18 +3,11 @@
 import * as GS from "@/styles/GlobalStyle";
 import * as S from "./UserSetting.styles";
 
-import { TopNavigator } from "@/components/navigators/TopNavigator";
-import { GoBackButton } from "@/components/navigators/TopNavigator/components";
 import { UserSettingAccount, UserSettingMember, UserSettingOptions } from "./components";
 
 const UserSettingView = () => {
   return (
     <GS.CommonContainer style={{ height: "100%" }}>
-      <TopNavigator
-        leftChildren={<GoBackButton />}
-        title={"설정"}
-      />
-
       <S.UserSettingLayout
         initial={{ x: "-100%" }}
         animate={{ x: 0 }}

--- a/src/app/user/[id]/setting/components/UserSettingMember/UserSettingMember.controller.tsx
+++ b/src/app/user/[id]/setting/components/UserSettingMember/UserSettingMember.controller.tsx
@@ -1,7 +1,15 @@
+import { usePathname, useRouter } from "next/navigation";
 import UserSettingMemberView from "./UserSettingMember.view";
 
 const UserSettingMemberController = () => {
-  return <UserSettingMemberView />;
+  const router = useRouter();
+  const pathName = usePathname();
+
+  const handleClick = () => {
+    router.push(`${pathName}/edit`);
+  };
+
+  return <UserSettingMemberView onClick={handleClick} />;
 };
 
 export default UserSettingMemberController;

--- a/src/app/user/[id]/setting/components/UserSettingMember/UserSettingMember.view.tsx
+++ b/src/app/user/[id]/setting/components/UserSettingMember/UserSettingMember.view.tsx
@@ -2,16 +2,19 @@ import { AccountManager } from "@/components/icons";
 import * as GS from "../../UserSetting.styles";
 import { SettingContent } from "..";
 
-const UserSettingMemberView = () => {
+interface UserSettingMemberViewProps {
+  onClick: () => void;
+}
+
+const UserSettingMemberView = ({ onClick }: UserSettingMemberViewProps) => {
   return (
     <GS.UserSettingInnerLayout>
       <GS.UserSettingTitle>회원</GS.UserSettingTitle>
 
-      {/* Route를 통한 페이지 이동 */}
       <SettingContent
         icon={<AccountManager />}
         text={"회원 수정"}
-        onClick={() => {}}
+        onClick={onClick}
       />
     </GS.UserSettingInnerLayout>
   );

--- a/src/app/user/[id]/setting/edit/UserEdit.constants.ts
+++ b/src/app/user/[id]/setting/edit/UserEdit.constants.ts
@@ -1,9 +1,6 @@
-import { USER_VALIDATE } from "@/constants/userValidate";
-
-export const USER_EDIT_ERROR_MESSAGE = {
-  NICKNAME: {
-    REQUIRE: "변경하실 닉네임을 입력해주세요.",
-    MIN_LENGTH: `${USER_VALIDATE.NICKNAME.MIN_LENGTH}글자 이상을 입력해 주세요.`,
-    MAX_LENGTH: `${USER_VALIDATE.NICKNAME.MAX_LENGTH}글자 이하로 입력해 주세요.`,
-  },
+export const USER_EDIT_PLACEHOLDER = {
+  NICKNAME: "수정하실 닉네임을 입력해주세요.",
+  BIRTHDAY: "수정하실 나이를 입력해주세요.",
+  HEIGHT: "수정하실 키를 입력해주세요.",
+  WEIGHT: "수정하실 몸무게를 입력해주세요.",
 };

--- a/src/app/user/[id]/setting/edit/UserEdit.constants.ts
+++ b/src/app/user/[id]/setting/edit/UserEdit.constants.ts
@@ -1,0 +1,9 @@
+import { USER_VALIDATE } from "@/constants/userValidate";
+
+export const USER_EDIT_ERROR_MESSAGE = {
+  NICKNAME: {
+    REQUIRE: "변경하실 닉네임을 입력해주세요.",
+    MIN_LENGTH: `${USER_VALIDATE.NICKNAME.MIN_LENGTH}글자 이상을 입력해 주세요.`,
+    MAX_LENGTH: `${USER_VALIDATE.NICKNAME.MAX_LENGTH}글자 이하로 입력해 주세요.`,
+  },
+};

--- a/src/app/user/[id]/setting/edit/UserEdit.constants.ts
+++ b/src/app/user/[id]/setting/edit/UserEdit.constants.ts
@@ -1,6 +1,6 @@
 export const USER_EDIT_PLACEHOLDER = {
   NICKNAME: "수정하실 닉네임을 입력해주세요.",
-  BIRTHDAY: "수정하실 나이를 입력해주세요.",
+  BIRTH_DATE: "수정하실 나이를 입력해주세요.",
   HEIGHT: "수정하실 키를 입력해주세요.",
   WEIGHT: "수정하실 몸무게를 입력해주세요.",
 };

--- a/src/app/user/[id]/setting/edit/UserEdit.controller.tsx
+++ b/src/app/user/[id]/setting/edit/UserEdit.controller.tsx
@@ -6,37 +6,40 @@ import { TopNavigator } from "@/components/navigators/TopNavigator";
 import { GoBackButton } from "@/components/navigators/TopNavigator/components";
 import { UserEditData } from "./UserEdit.types";
 import useUserEditModel from "./UserEdit.model";
+import { useEffect } from "react";
 
 interface UserEditControllerProps {
-  userId: string;
+  userData: UserEditData;
 }
 
-const FORM_DEFAULT_VALUE: UserEditData = {
-  nickname: "임시값닉네임",
-  sex: "male",
-  age: 12,
-  height: 182,
-  weight: 150,
-};
-
 // userId 는 추후 유저의 데이터를 불러올때 사용
-const UserEditController = ({ userId }: UserEditControllerProps) => {
+const UserEditController = ({ userData }: UserEditControllerProps) => {
   const { isCheckedNickname, setIsCheckedNickname } = useUserEditModel();
-  const { register, handleSubmit, formState, getValues } = useForm<UserEditData>({
+  const { register, handleSubmit, watch, formState, getValues } = useForm<UserEditData>({
     mode: "onChange",
-    defaultValues: FORM_DEFAULT_VALUE,
+    defaultValues: userData,
   });
   const { errors } = formState;
 
-  const handleChangeNickname = () => {
-    if (!isCheckedNickname) {
+  const newNickname = watch("nickname");
+  useEffect(() => {
+    if (userData.nickname === newNickname) {
+      setIsCheckedNickname(true);
       return;
     }
-    setIsCheckedNickname(false);
-  };
+
+    if (isCheckedNickname) {
+      setIsCheckedNickname(false);
+    }
+  }, [newNickname]);
 
   const handleValid = (data: UserEditData) => {
     console.log(data);
+    /*
+      TODO
+
+      최종 검증 후 업데이트 로직 수행
+    */
   };
 
   const handleInValid = (error: FieldErrors) => {
@@ -64,12 +67,10 @@ const UserEditController = ({ userId }: UserEditControllerProps) => {
       <UserEditView
         register={register}
         errors={errors}
-        getValues={getValues}
         onValid={handleValid}
         onInValid={handleInValid}
         onSubmit={handleSubmit}
         isCheckedNickname={isCheckedNickname}
-        onChangeNickname={handleChangeNickname}
         onCheckSameNickname={handleCheckSameNickName}
       />
     </>

--- a/src/app/user/[id]/setting/edit/UserEdit.controller.tsx
+++ b/src/app/user/[id]/setting/edit/UserEdit.controller.tsx
@@ -22,6 +22,7 @@ const UserEditController = ({ userData }: UserEditControllerProps) => {
   const { errors } = formState;
 
   const newNickname = watch("nickname");
+  const selectedValue = watch("sex");
   useEffect(() => {
     if (userData.nickname === newNickname) {
       setIsCheckedNickname(true);

--- a/src/app/user/[id]/setting/edit/UserEdit.controller.tsx
+++ b/src/app/user/[id]/setting/edit/UserEdit.controller.tsx
@@ -2,6 +2,8 @@
 
 import { useForm } from "react-hook-form";
 import UserEditView from "./UserEdit.view";
+import { TopNavigator } from "@/components/navigators/TopNavigator";
+import { GoBackButton } from "@/components/navigators/TopNavigator/components";
 
 interface UserEditControllerProps {
   userId: string;
@@ -31,7 +33,15 @@ const UserEditController = ({ userId }: UserEditControllerProps) => {
 
   // 추후 userId를 이용해 사용자 정보를 호출할 예정
   console.log(userId);
-  return <UserEditView />;
+  return (
+    <>
+      <TopNavigator
+        leftChildren={<GoBackButton />}
+        title={"회원 정보 수정"}
+      />
+      <UserEditView />
+    </>
+  );
 };
 
 export default UserEditController;

--- a/src/app/user/[id]/setting/edit/UserEdit.controller.tsx
+++ b/src/app/user/[id]/setting/edit/UserEdit.controller.tsx
@@ -22,7 +22,7 @@ const FORM_DEFAULT_VALUE: UserEditData = {
 // userId 는 추후 유저의 데이터를 불러올때 사용
 const UserEditController = ({ userId }: UserEditControllerProps) => {
   const { isCheckedNickname, setIsCheckedNickname } = useUserEditModel();
-  const { register, handleSubmit, formState } = useForm<UserEditData>({
+  const { register, handleSubmit, formState, getValues } = useForm<UserEditData>({
     mode: "onChange",
     defaultValues: FORM_DEFAULT_VALUE,
   });
@@ -32,8 +32,7 @@ const UserEditController = ({ userId }: UserEditControllerProps) => {
     if (!isCheckedNickname) {
       return;
     }
-
-    setIsCheckedNickname((state) => !state);
+    setIsCheckedNickname(false);
   };
 
   const handleValid = (data: UserEditData) => {
@@ -44,6 +43,18 @@ const UserEditController = ({ userId }: UserEditControllerProps) => {
     console.log(error);
   };
 
+  const handleCheckSameNickName = () => {
+    const newNickname = getValues("nickname");
+
+    // TODO - API 연결로 인해 중복 닉네임 체크후 없는 닉네임이라면 통과처리
+
+    // if(){
+    //   console.log(newNickname);
+    // }
+
+    setIsCheckedNickname(true);
+  };
+
   return (
     <>
       <TopNavigator
@@ -52,11 +63,14 @@ const UserEditController = ({ userId }: UserEditControllerProps) => {
       />
       <UserEditView
         register={register}
+        errors={errors}
+        getValues={getValues}
         onValid={handleValid}
         onInValid={handleInValid}
         onSubmit={handleSubmit}
-        errors={errors}
+        isCheckedNickname={isCheckedNickname}
         onChangeNickname={handleChangeNickname}
+        onCheckSameNickname={handleCheckSameNickName}
       />
     </>
   );

--- a/src/app/user/[id]/setting/edit/UserEdit.controller.tsx
+++ b/src/app/user/[id]/setting/edit/UserEdit.controller.tsx
@@ -16,7 +16,6 @@ interface UserEditControllerProps {
 const UserEditController = ({ userData }: UserEditControllerProps) => {
   const { isCheckedNickname, setIsCheckedNickname } = useUserEditModel();
   const { register, handleSubmit, watch, formState, getValues } = useForm<UserEditData>({
-    mode: "onChange",
     defaultValues: userData,
   });
   const { errors } = formState;

--- a/src/app/user/[id]/setting/edit/UserEdit.controller.tsx
+++ b/src/app/user/[id]/setting/edit/UserEdit.controller.tsx
@@ -22,7 +22,8 @@ const UserEditController = ({ userData }: UserEditControllerProps) => {
   const { errors } = formState;
 
   const newNickname = watch("nickname");
-  const selectedValue = watch("sex");
+  const selectedSex = watch("sex");
+
   useEffect(() => {
     if (userData.nickname === newNickname) {
       setIsCheckedNickname(true);
@@ -71,6 +72,7 @@ const UserEditController = ({ userData }: UserEditControllerProps) => {
         onValid={handleValid}
         onInValid={handleInValid}
         onSubmit={handleSubmit}
+        selectedSex={selectedSex}
         isCheckedNickname={isCheckedNickname}
         onCheckSameNickname={handleCheckSameNickName}
       />

--- a/src/app/user/[id]/setting/edit/UserEdit.controller.tsx
+++ b/src/app/user/[id]/setting/edit/UserEdit.controller.tsx
@@ -26,7 +26,7 @@ const UserEditController = ({ userId }: UserEditControllerProps) => {
     mode: "onChange",
     defaultValues: FORM_DEFAULT_VALUE,
   });
-  console.log(!!formState.errors.nickname);
+  const { errors } = formState;
 
   const handleChangeNickname = () => {
     if (!isCheckedNickname) {
@@ -55,6 +55,7 @@ const UserEditController = ({ userId }: UserEditControllerProps) => {
         onValid={handleValid}
         onInValid={handleInValid}
         onSubmit={handleSubmit}
+        errors={errors}
         onChangeNickname={handleChangeNickname}
       />
     </>

--- a/src/app/user/[id]/setting/edit/UserEdit.controller.tsx
+++ b/src/app/user/[id]/setting/edit/UserEdit.controller.tsx
@@ -1,45 +1,62 @@
 "use client";
 
-import { useForm } from "react-hook-form";
+import { FieldErrors, useForm } from "react-hook-form";
 import UserEditView from "./UserEdit.view";
 import { TopNavigator } from "@/components/navigators/TopNavigator";
 import { GoBackButton } from "@/components/navigators/TopNavigator/components";
+import { UserEditData } from "./UserEdit.types";
+import useUserEditModel from "./UserEdit.model";
 
 interface UserEditControllerProps {
   userId: string;
 }
 
-interface UserData {
-  nickname: string;
-  sex: "male" | "female";
-  age: number;
-  height: number;
-  weight: number;
-}
-
-const FORM_DEFAULT_VALUE: UserData = {
-  nickname: "",
+const FORM_DEFAULT_VALUE: UserEditData = {
+  nickname: "임시값닉네임",
   sex: "male",
   age: 12,
   height: 182,
   weight: 150,
 };
 
+// userId 는 추후 유저의 데이터를 불러올때 사용
 const UserEditController = ({ userId }: UserEditControllerProps) => {
-  const {} = useForm<UserData>({
+  const { isCheckedNickname, setIsCheckedNickname } = useUserEditModel();
+  const { register, handleSubmit, formState } = useForm<UserEditData>({
     mode: "onChange",
     defaultValues: FORM_DEFAULT_VALUE,
   });
+  console.log(!!formState.errors.nickname);
 
-  // 추후 userId를 이용해 사용자 정보를 호출할 예정
-  console.log(userId);
+  const handleChangeNickname = () => {
+    if (!isCheckedNickname) {
+      return;
+    }
+
+    setIsCheckedNickname((state) => !state);
+  };
+
+  const handleValid = (data: UserEditData) => {
+    console.log(data);
+  };
+
+  const handleInValid = (error: FieldErrors) => {
+    console.log(error);
+  };
+
   return (
     <>
       <TopNavigator
         leftChildren={<GoBackButton />}
         title={"회원 정보 수정"}
       />
-      <UserEditView />
+      <UserEditView
+        register={register}
+        onValid={handleValid}
+        onInValid={handleInValid}
+        onSubmit={handleSubmit}
+        onChangeNickname={handleChangeNickname}
+      />
     </>
   );
 };

--- a/src/app/user/[id]/setting/edit/UserEdit.controller.tsx
+++ b/src/app/user/[id]/setting/edit/UserEdit.controller.tsx
@@ -22,6 +22,7 @@ const UserEditController = ({ userData }: UserEditControllerProps) => {
 
   const newNickname = watch("nickname");
   const selectedSex = watch("sex");
+  const selectedIntensity = watch("intensity");
 
   useEffect(() => {
     if (userData.nickname === newNickname) {
@@ -72,6 +73,7 @@ const UserEditController = ({ userData }: UserEditControllerProps) => {
         onInValid={handleInValid}
         onSubmit={handleSubmit}
         selectedSex={selectedSex}
+        selectedIntensity={selectedIntensity}
         isCheckedNickname={isCheckedNickname}
         onCheckSameNickname={handleCheckSameNickName}
       />

--- a/src/app/user/[id]/setting/edit/UserEdit.model.ts
+++ b/src/app/user/[id]/setting/edit/UserEdit.model.ts
@@ -1,0 +1,12 @@
+import { useState } from "react";
+
+const useUserEditModel = () => {
+  const [isCheckedNickname, setIsCheckedNickname] = useState(true);
+
+  return {
+    isCheckedNickname,
+    setIsCheckedNickname,
+  };
+};
+
+export default useUserEditModel;

--- a/src/app/user/[id]/setting/edit/UserEdit.styles.ts
+++ b/src/app/user/[id]/setting/edit/UserEdit.styles.ts
@@ -1,3 +1,4 @@
+import { FONT_SIZE, FONT_WEIGHT } from "@/styles/theme";
 import styled from "styled-components";
 
 export const UserEditLayout = styled.form`
@@ -10,4 +11,14 @@ export const UserEditLayout = styled.form`
   gap: 2rem;
 
   border: 1px solid red;
+`;
+
+export const UserEditTitle = styled.h6`
+  margin-bottom: 1.6rem;
+  padding-left: 0.6rem;
+
+  font-size: ${FONT_SIZE.H6};
+  font-weight: ${FONT_WEIGHT.BOLD};
+
+  user-select: none;
 `;

--- a/src/app/user/[id]/setting/edit/UserEdit.styles.ts
+++ b/src/app/user/[id]/setting/edit/UserEdit.styles.ts
@@ -4,20 +4,17 @@ import styled from "styled-components";
 export const UserEditLayout = styled.form`
   width: 100%;
   height: 100%;
-  padding: 0 1.6rem;
 
   display: flex;
   flex-direction: column;
   gap: 2rem;
-
-  border: 1px solid red;
 `;
 
 export const UserEditTitle = styled.h6`
   margin-bottom: 1.6rem;
   padding-left: 0.6rem;
 
-  font-size: ${FONT_SIZE.H6};
+  font-size: ${FONT_SIZE.H5};
   font-weight: ${FONT_WEIGHT.BOLD};
 
   user-select: none;

--- a/src/app/user/[id]/setting/edit/UserEdit.styles.ts
+++ b/src/app/user/[id]/setting/edit/UserEdit.styles.ts
@@ -17,6 +17,13 @@ export const UserEditLayout = styled(motion.form)`
 
 export const UserEditSectionContainer = styled.div`
   width: 100%;
+
+  overflow-y: scroll;
+  ${DISPLAY_NONE_SCROLLBAR}
+`;
+
+export const UserEditSectionContainer = styled.div`
+  width: 100%;
 `;
 
 export const UserEditTitle = styled.h6`
@@ -31,15 +38,9 @@ export const UserEditTitle = styled.h6`
 
 export const UserEditWarning = styled.div`
   width: 100%;
-  min-height: 2.4rem;
+  min-height: 2.8rem;
   padding-left: 0.6rem;
 
   display: flex;
   align-items: center;
-
-  white-space: nowrap;
-
-  overflow: scroll;
-
-  ${DISPLAY_NONE_SCROLLBAR}
 `;

--- a/src/app/user/[id]/setting/edit/UserEdit.styles.ts
+++ b/src/app/user/[id]/setting/edit/UserEdit.styles.ts
@@ -15,15 +15,11 @@ export const UserEditLayout = styled(motion.form)`
   ${DISPLAY_NONE_SCROLLBAR}
 `;
 
-export const UserEditSectionContainer = styled.div`
+export const UserEditSectionContainer = styled.article`
   width: 100%;
 
   overflow-y: scroll;
   ${DISPLAY_NONE_SCROLLBAR}
-`;
-
-export const UserEditSectionContainer = styled.div`
-  width: 100%;
 `;
 
 export const UserEditTitle = styled.h6`

--- a/src/app/user/[id]/setting/edit/UserEdit.styles.ts
+++ b/src/app/user/[id]/setting/edit/UserEdit.styles.ts
@@ -1,13 +1,22 @@
-import { FONT_SIZE, FONT_WEIGHT } from "@/styles/theme";
+import { DISPLAY_NONE_SCROLLBAR, FONT_SIZE, FONT_WEIGHT } from "@/styles/theme";
+import { motion } from "framer-motion";
 import styled from "styled-components";
 
-export const UserEditLayout = styled.form`
+export const UserEditLayout = styled(motion.form)`
   width: 100%;
   height: 100%;
+  padding: 2rem 0;
 
   display: flex;
   flex-direction: column;
   gap: 2rem;
+
+  overflow-y: scroll;
+  ${DISPLAY_NONE_SCROLLBAR}
+`;
+
+export const UserEditSectionContainer = styled.div`
+  width: 100%;
 `;
 
 export const UserEditTitle = styled.h6`
@@ -18,4 +27,19 @@ export const UserEditTitle = styled.h6`
   font-weight: ${FONT_WEIGHT.BOLD};
 
   user-select: none;
+`;
+
+export const UserEditWarning = styled.div`
+  width: 100%;
+  min-height: 2.4rem;
+  padding-left: 0.6rem;
+
+  display: flex;
+  align-items: center;
+
+  white-space: nowrap;
+
+  overflow: scroll;
+
+  ${DISPLAY_NONE_SCROLLBAR}
 `;

--- a/src/app/user/[id]/setting/edit/UserEdit.types.ts
+++ b/src/app/user/[id]/setting/edit/UserEdit.types.ts
@@ -1,7 +1,10 @@
+export type IntensityType = "SUPER_LOW" | "LOW" | "MIDDLE" | "HIGH" | "SUPER_HIGH" | "";
+
 export interface UserEditData {
   nickname: string;
   sex: "male" | "female";
-  age: number;
+  birthDay: string;
   height: number;
   weight: number;
+  intensity: IntensityType;
 }

--- a/src/app/user/[id]/setting/edit/UserEdit.types.ts
+++ b/src/app/user/[id]/setting/edit/UserEdit.types.ts
@@ -3,7 +3,7 @@ import { IntensityOption } from "@/types/OriginDataType";
 export interface UserEditData {
   nickname: string;
   sex: "male" | "female";
-  birthDay: string;
+  birthDate: string;
   height: number;
   weight: number;
   intensity: IntensityOption;

--- a/src/app/user/[id]/setting/edit/UserEdit.types.ts
+++ b/src/app/user/[id]/setting/edit/UserEdit.types.ts
@@ -1,0 +1,7 @@
+export interface UserEditData {
+  nickname: string;
+  sex: "male" | "female";
+  age: number;
+  height: number;
+  weight: number;
+}

--- a/src/app/user/[id]/setting/edit/UserEdit.types.ts
+++ b/src/app/user/[id]/setting/edit/UserEdit.types.ts
@@ -1,4 +1,4 @@
-export type IntensityType = "SUPER_LOW" | "LOW" | "MIDDLE" | "HIGH" | "SUPER_HIGH" | "";
+import { IntensityOption } from "@/types/OriginDataType";
 
 export interface UserEditData {
   nickname: string;
@@ -6,5 +6,5 @@ export interface UserEditData {
   birthDay: string;
   height: number;
   weight: number;
-  intensity: IntensityType;
+  intensity: IntensityOption;
 }

--- a/src/app/user/[id]/setting/edit/UserEdit.view.tsx
+++ b/src/app/user/[id]/setting/edit/UserEdit.view.tsx
@@ -2,7 +2,7 @@ import * as GS from "@/styles/GlobalStyle";
 import * as S from "./UserEdit.styles";
 
 import { FieldErrors, UseFormHandleSubmit, UseFormRegister } from "react-hook-form";
-import { IntensityType, UserEditData } from "./UserEdit.types";
+import { UserEditData } from "./UserEdit.types";
 
 import { EditSex, EditNickname, EditBirthDay, EditBodyInfo, EditIntensity } from "./components";
 import { Button } from "@/components";
@@ -48,10 +48,6 @@ const UserEditView = ({
         initial={{ x: "-120%" }}
         animate={{ x: 0 }}
       >
-      <S.UserEditLayout
-        initial={{ x: "-120%" }}
-        animate={{ x: 0 }}
-      >
         <EditNickname
           register={register}
           errors={errors}
@@ -64,10 +60,6 @@ const UserEditView = ({
           selectedSex={selectedSex}
         />
 
-        <EditBirthDay
-          register={register}
-          errors={errors}
-        />
         <EditBirthDay
           register={register}
           errors={errors}

--- a/src/app/user/[id]/setting/edit/UserEdit.view.tsx
+++ b/src/app/user/[id]/setting/edit/UserEdit.view.tsx
@@ -1,18 +1,11 @@
 import * as GS from "@/styles/GlobalStyle";
 import * as S from "./UserEdit.styles";
-import { TopNavigator } from "@/components/navigators/TopNavigator";
-import { GoBackButton } from "@/components/navigators/TopNavigator/components";
 
 interface UserEditViewProps {}
 
 const UserEditView = ({}: UserEditViewProps) => {
   return (
     <GS.CommonContainer style={{ height: "100%" }}>
-      <TopNavigator
-        leftChildren={<GoBackButton />}
-        title={"회원 정보 수정"}
-      />
-
       <S.UserEditLayout>
         <div>닉네임</div>
 

--- a/src/app/user/[id]/setting/edit/UserEdit.view.tsx
+++ b/src/app/user/[id]/setting/edit/UserEdit.view.tsx
@@ -1,7 +1,12 @@
 import * as GS from "@/styles/GlobalStyle";
 import * as S from "./UserEdit.styles";
 
-import { FieldErrors, UseFormHandleSubmit, UseFormRegister } from "react-hook-form";
+import {
+  FieldErrors,
+  UseFormGetValues,
+  UseFormHandleSubmit,
+  UseFormRegister,
+} from "react-hook-form";
 import { UserEditData } from "./UserEdit.types";
 
 import { EditNickname } from "./components";
@@ -10,21 +15,28 @@ interface UserEditViewProps {
   register: UseFormRegister<UserEditData>;
   errors: FieldErrors<UserEditData>;
 
+  getValues: UseFormGetValues<UserEditData>;
   onSubmit: UseFormHandleSubmit<UserEditData>;
   onValid: (data: UserEditData) => void;
   onInValid: (error: FieldErrors) => void;
 
+  isCheckedNickname: boolean;
   onChangeNickname: () => void;
+  onCheckSameNickname: () => void;
 }
 
 const UserEditView = ({
   register,
   errors,
 
+  getValues,
   onSubmit,
   onValid,
   onInValid,
+
+  isCheckedNickname,
   onChangeNickname,
+  onCheckSameNickname,
 }: UserEditViewProps) => {
   return (
     <GS.CommonContainer
@@ -35,7 +47,9 @@ const UserEditView = ({
         <EditNickname
           register={register}
           errors={errors}
+          isCheckedNickname={isCheckedNickname}
           onChangeNickname={onChangeNickname}
+          onCheckSameNickname={onCheckSameNickname}
         />
 
         <div>성별</div>

--- a/src/app/user/[id]/setting/edit/UserEdit.view.tsx
+++ b/src/app/user/[id]/setting/edit/UserEdit.view.tsx
@@ -4,7 +4,7 @@ import * as S from "./UserEdit.styles";
 import { FieldErrors, UseFormHandleSubmit, UseFormRegister } from "react-hook-form";
 import { UserEditData } from "./UserEdit.types";
 
-import { EditSex, EditNickname, EditBirthDay, EditBodyInfo, EditIntensity } from "./components";
+import { EditSex, EditNickname, EditBirthDate, EditBodyInfo, EditIntensity } from "./components";
 import { Button } from "@/components";
 import useTheme from "@/lib/hooks/useTheme";
 import { FONT_SIZE, FONT_WEIGHT } from "@/styles/theme";
@@ -60,7 +60,7 @@ const UserEditView = ({
           selectedSex={selectedSex}
         />
 
-        <EditBirthDay
+        <EditBirthDate
           register={register}
           errors={errors}
         />

--- a/src/app/user/[id]/setting/edit/UserEdit.view.tsx
+++ b/src/app/user/[id]/setting/edit/UserEdit.view.tsx
@@ -2,9 +2,12 @@ import * as GS from "@/styles/GlobalStyle";
 import * as S from "./UserEdit.styles";
 
 import { FieldErrors, UseFormHandleSubmit, UseFormRegister } from "react-hook-form";
-import { UserEditData } from "./UserEdit.types";
+import { IntensityType, UserEditData } from "./UserEdit.types";
 
-import { EditSex, EditNickname } from "./components";
+import { EditSex, EditNickname, EditBirthDay, EditBodyInfo, EditIntensity } from "./components";
+import { Button } from "@/components";
+import useTheme from "@/lib/hooks/useTheme";
+import { FONT_SIZE, FONT_WEIGHT } from "@/styles/theme";
 
 interface UserEditViewProps {
   register: UseFormRegister<UserEditData>;
@@ -15,6 +18,7 @@ interface UserEditViewProps {
   onInValid: (error: FieldErrors) => void;
 
   selectedSex: string;
+  selectedIntensity: IntensityType;
   isCheckedNickname: boolean;
   onCheckSameNickname: () => void;
 }
@@ -28,15 +32,25 @@ const UserEditView = ({
   onInValid,
 
   selectedSex,
+  selectedIntensity,
   isCheckedNickname,
   onCheckSameNickname,
 }: UserEditViewProps) => {
+  const theme = useTheme();
+
+  if (!theme) {
+    return;
+  }
+
   return (
     <GS.CommonContainer
       style={{ height: "100%" }}
       onSubmit={onSubmit(onValid, onInValid)}
     >
-      <S.UserEditLayout>
+      <S.UserEditLayout
+        initial={{ x: "-120%" }}
+        animate={{ x: 0 }}
+      >
         <EditNickname
           register={register}
           errors={errors}
@@ -49,13 +63,35 @@ const UserEditView = ({
           selectedSex={selectedSex}
         />
 
-        <div>나이</div>
+        <EditBirthDay
+          register={register}
+          errors={errors}
+        />
 
-        <div>키 , 체중</div>
+        <EditBodyInfo
+          register={register}
+          errors={errors}
+        />
 
-        <div>강도</div>
+        <EditIntensity
+          register={register}
+          selectedIntensity={selectedIntensity}
+        />
 
-        <button>테스트용 제출 버튼</button>
+        <Button
+          variant="flat"
+          useRipple
+          rippleColor={theme.text_secondary_color + 50}
+          buttonColor={theme.green_500}
+          textColor={theme.text_secondary_color}
+          style={{
+            fontSize: FONT_SIZE.H4,
+            fontWeight: FONT_WEIGHT.BOLD,
+            minHeight: "5rem",
+          }}
+        >
+          수정 완료
+        </Button>
       </S.UserEditLayout>
     </GS.CommonContainer>
   );

--- a/src/app/user/[id]/setting/edit/UserEdit.view.tsx
+++ b/src/app/user/[id]/setting/edit/UserEdit.view.tsx
@@ -8,6 +8,8 @@ import { EditNickname } from "./components";
 
 interface UserEditViewProps {
   register: UseFormRegister<UserEditData>;
+  errors: FieldErrors<UserEditData>;
+
   onSubmit: UseFormHandleSubmit<UserEditData>;
   onValid: (data: UserEditData) => void;
   onInValid: (error: FieldErrors) => void;
@@ -17,6 +19,8 @@ interface UserEditViewProps {
 
 const UserEditView = ({
   register,
+  errors,
+
   onSubmit,
   onValid,
   onInValid,
@@ -30,6 +34,7 @@ const UserEditView = ({
       <S.UserEditLayout>
         <EditNickname
           register={register}
+          errors={errors}
           onChangeNickname={onChangeNickname}
         />
 

--- a/src/app/user/[id]/setting/edit/UserEdit.view.tsx
+++ b/src/app/user/[id]/setting/edit/UserEdit.view.tsx
@@ -8,6 +8,7 @@ import { EditSex, EditNickname, EditBirthDay, EditBodyInfo, EditIntensity } from
 import { Button } from "@/components";
 import useTheme from "@/lib/hooks/useTheme";
 import { FONT_SIZE, FONT_WEIGHT } from "@/styles/theme";
+import { IntensityOption } from "@/types/OriginDataType";
 
 interface UserEditViewProps {
   register: UseFormRegister<UserEditData>;
@@ -18,7 +19,7 @@ interface UserEditViewProps {
   onInValid: (error: FieldErrors) => void;
 
   selectedSex: string;
-  selectedIntensity: IntensityType;
+  selectedIntensity: IntensityOption;
   isCheckedNickname: boolean;
   onCheckSameNickname: () => void;
 }
@@ -38,15 +39,15 @@ const UserEditView = ({
 }: UserEditViewProps) => {
   const theme = useTheme();
 
-  if (!theme) {
-    return;
-  }
-
   return (
     <GS.CommonContainer
       style={{ height: "100%" }}
       onSubmit={onSubmit(onValid, onInValid)}
     >
+      <S.UserEditLayout
+        initial={{ x: "-120%" }}
+        animate={{ x: 0 }}
+      >
       <S.UserEditLayout
         initial={{ x: "-120%" }}
         animate={{ x: 0 }}
@@ -67,6 +68,10 @@ const UserEditView = ({
           register={register}
           errors={errors}
         />
+        <EditBirthDay
+          register={register}
+          errors={errors}
+        />
 
         <EditBodyInfo
           register={register}
@@ -81,9 +86,9 @@ const UserEditView = ({
         <Button
           variant="flat"
           useRipple
-          rippleColor={theme.text_secondary_color + 50}
-          buttonColor={theme.green_500}
-          textColor={theme.text_secondary_color}
+          rippleColor={theme?.text_secondary_color + 50}
+          buttonColor={theme?.green_500}
+          textColor={theme?.text_secondary_color}
           style={{
             fontSize: FONT_SIZE.H4,
             fontWeight: FONT_WEIGHT.BOLD,

--- a/src/app/user/[id]/setting/edit/UserEdit.view.tsx
+++ b/src/app/user/[id]/setting/edit/UserEdit.view.tsx
@@ -1,14 +1,39 @@
 import * as GS from "@/styles/GlobalStyle";
 import * as S from "./UserEdit.styles";
 
-interface UserEditViewProps {}
+import { FieldErrors, UseFormHandleSubmit, UseFormRegister } from "react-hook-form";
+import { UserEditData } from "./UserEdit.types";
 
-const UserEditView = ({}: UserEditViewProps) => {
+import useTheme from "@/lib/hooks/useTheme";
+import { EditNickname } from "./components";
+
+interface UserEditViewProps {
+  register: UseFormRegister<UserEditData>;
+  onSubmit: UseFormHandleSubmit<UserEditData>;
+  onValid: (data: UserEditData) => void;
+  onInValid: (error: FieldErrors) => void;
+
+  onChangeNickname: () => void;
+}
+
+const UserEditView = ({
+  register,
+  onSubmit,
+  onValid,
+  onInValid,
+  onChangeNickname,
+}: UserEditViewProps) => {
+  const theme = useTheme();
+  if (!theme) {
+    return;
+  }
+
   return (
-    <GS.CommonContainer style={{ height: "100%" }}>
+    <GS.CommonContainer
+      style={{ height: "100%" }}
+      onSubmit={onSubmit(onValid, onInValid)}
+    >
       <S.UserEditLayout>
-        <div>닉네임</div>
-
         <div>성별</div>
 
         <div>나이</div>
@@ -16,6 +41,8 @@ const UserEditView = ({}: UserEditViewProps) => {
         <div>키 , 체중</div>
 
         <div>강도</div>
+
+        <button>테스트용 제출 버튼</button>
       </S.UserEditLayout>
     </GS.CommonContainer>
   );

--- a/src/app/user/[id]/setting/edit/UserEdit.view.tsx
+++ b/src/app/user/[id]/setting/edit/UserEdit.view.tsx
@@ -1,15 +1,10 @@
 import * as GS from "@/styles/GlobalStyle";
 import * as S from "./UserEdit.styles";
 
-import {
-  FieldErrors,
-  UseFormGetValues,
-  UseFormHandleSubmit,
-  UseFormRegister,
-} from "react-hook-form";
+import { FieldErrors, UseFormHandleSubmit, UseFormRegister } from "react-hook-form";
 import { UserEditData } from "./UserEdit.types";
 
-import { EditAge, EditNickname } from "./components";
+import { EditSex, EditNickname } from "./components";
 
 interface UserEditViewProps {
   register: UseFormRegister<UserEditData>;
@@ -47,7 +42,7 @@ const UserEditView = ({
           onCheckSameNickname={onCheckSameNickname}
         />
 
-        <EditAge register={register} />
+        <EditSex register={register} />
 
         <div>나이</div>
 

--- a/src/app/user/[id]/setting/edit/UserEdit.view.tsx
+++ b/src/app/user/[id]/setting/edit/UserEdit.view.tsx
@@ -4,7 +4,6 @@ import * as S from "./UserEdit.styles";
 import { FieldErrors, UseFormHandleSubmit, UseFormRegister } from "react-hook-form";
 import { UserEditData } from "./UserEdit.types";
 
-import useTheme from "@/lib/hooks/useTheme";
 import { EditNickname } from "./components";
 
 interface UserEditViewProps {
@@ -23,11 +22,6 @@ const UserEditView = ({
   onInValid,
   onChangeNickname,
 }: UserEditViewProps) => {
-  const theme = useTheme();
-  if (!theme) {
-    return;
-  }
-
   return (
     <GS.CommonContainer
       style={{ height: "100%" }}

--- a/src/app/user/[id]/setting/edit/UserEdit.view.tsx
+++ b/src/app/user/[id]/setting/edit/UserEdit.view.tsx
@@ -34,6 +34,11 @@ const UserEditView = ({
       onSubmit={onSubmit(onValid, onInValid)}
     >
       <S.UserEditLayout>
+        <EditNickname
+          register={register}
+          onChangeNickname={onChangeNickname}
+        />
+
         <div>성별</div>
 
         <div>나이</div>

--- a/src/app/user/[id]/setting/edit/UserEdit.view.tsx
+++ b/src/app/user/[id]/setting/edit/UserEdit.view.tsx
@@ -15,13 +15,11 @@ interface UserEditViewProps {
   register: UseFormRegister<UserEditData>;
   errors: FieldErrors<UserEditData>;
 
-  getValues: UseFormGetValues<UserEditData>;
   onSubmit: UseFormHandleSubmit<UserEditData>;
   onValid: (data: UserEditData) => void;
   onInValid: (error: FieldErrors) => void;
 
   isCheckedNickname: boolean;
-  onChangeNickname: () => void;
   onCheckSameNickname: () => void;
 }
 
@@ -29,13 +27,11 @@ const UserEditView = ({
   register,
   errors,
 
-  getValues,
   onSubmit,
   onValid,
   onInValid,
 
   isCheckedNickname,
-  onChangeNickname,
   onCheckSameNickname,
 }: UserEditViewProps) => {
   return (
@@ -48,7 +44,6 @@ const UserEditView = ({
           register={register}
           errors={errors}
           isCheckedNickname={isCheckedNickname}
-          onChangeNickname={onChangeNickname}
           onCheckSameNickname={onCheckSameNickname}
         />
 

--- a/src/app/user/[id]/setting/edit/UserEdit.view.tsx
+++ b/src/app/user/[id]/setting/edit/UserEdit.view.tsx
@@ -9,7 +9,7 @@ import {
 } from "react-hook-form";
 import { UserEditData } from "./UserEdit.types";
 
-import { EditNickname } from "./components";
+import { EditAge, EditNickname } from "./components";
 
 interface UserEditViewProps {
   register: UseFormRegister<UserEditData>;
@@ -47,7 +47,7 @@ const UserEditView = ({
           onCheckSameNickname={onCheckSameNickname}
         />
 
-        <div>성별</div>
+        <EditAge register={register} />
 
         <div>나이</div>
 

--- a/src/app/user/[id]/setting/edit/UserEdit.view.tsx
+++ b/src/app/user/[id]/setting/edit/UserEdit.view.tsx
@@ -14,6 +14,7 @@ interface UserEditViewProps {
   onValid: (data: UserEditData) => void;
   onInValid: (error: FieldErrors) => void;
 
+  selectedSex: string;
   isCheckedNickname: boolean;
   onCheckSameNickname: () => void;
 }
@@ -26,6 +27,7 @@ const UserEditView = ({
   onValid,
   onInValid,
 
+  selectedSex,
   isCheckedNickname,
   onCheckSameNickname,
 }: UserEditViewProps) => {
@@ -42,7 +44,10 @@ const UserEditView = ({
           onCheckSameNickname={onCheckSameNickname}
         />
 
-        <EditSex register={register} />
+        <EditSex
+          register={register}
+          selectedSex={selectedSex}
+        />
 
         <div>나이</div>
 

--- a/src/app/user/[id]/setting/edit/components/EditAge/EditAge.styles.ts
+++ b/src/app/user/[id]/setting/edit/components/EditAge/EditAge.styles.ts
@@ -1,0 +1,33 @@
+import { FONT_SIZE, FONT_WEIGHT } from "@/styles/theme";
+import styled from "styled-components";
+
+export const EditAgeContainer = styled.div`
+  width: 100%;
+
+  border: 1px solid red;
+`;
+
+export const EditAgeActions = styled.div`
+  display: flex;
+  gap: 2rem;
+`;
+
+export const InputRadioLabel = styled.label<{ $isSelected: boolean }>`
+  padding: 1.5rem;
+  width: 100%;
+
+  display: flex;
+  align-items: center;
+  justify-content: center;
+
+  border-radius: 0.8rem;
+
+  font-size: ${FONT_SIZE.LARGE};
+  font-weight: ${FONT_WEIGHT.BOLD};
+  letter-spacing: 1px;
+  white-space: nowrap;
+
+  user-select: none;
+
+  border: 1px solid red;
+`;

--- a/src/app/user/[id]/setting/edit/components/EditAge/EditAge.tsx
+++ b/src/app/user/[id]/setting/edit/components/EditAge/EditAge.tsx
@@ -1,0 +1,60 @@
+import { UseFormRegister, UseFormRegisterReturn } from "react-hook-form";
+import * as GS from "../../UserEdit.styles";
+import * as S from "./EditAge.styles";
+import { UserEditData } from "../../UserEdit.types";
+interface EditAgeProps {
+  register: UseFormRegister<UserEditData>;
+}
+const EditAge = ({ register }: EditAgeProps) => {
+  const options = [
+    { text: "남성", value: "male" },
+    { text: "여성", value: "female" },
+  ];
+
+  return (
+    <S.EditAgeContainer>
+      <GS.UserEditTitle>성별</GS.UserEditTitle>
+
+      <S.EditAgeActions>
+        {options.map(({ text, value }) => (
+          <InputRadio
+            key={`${text}_${value}`}
+            value={value}
+            text={text}
+            register={register("sex", { required: "성별의 입력은 필수" })}
+          />
+        ))}
+      </S.EditAgeActions>
+    </S.EditAgeContainer>
+  );
+};
+
+export default EditAge;
+
+interface createInputRadioProps {
+  register: UseFormRegisterReturn;
+  value: string | number;
+  text: string;
+  isSelected: boolean;
+  key?: string | number;
+}
+const InputRadio = ({ value, text, register, isSelected }: createInputRadioProps) => {
+  return (
+    <>
+      <input
+        type="radio"
+        id={`${text}_${value}`}
+        value={value}
+        style={{ display: "none" }}
+        {...register}
+      />
+
+      <S.InputRadioLabel
+        htmlFor={`${text}_${value}`}
+        $isSelected={isSelected}
+      >
+        {text}
+      </S.InputRadioLabel>
+    </>
+  );
+};

--- a/src/app/user/[id]/setting/edit/components/EditBirthDate/EditBirthDate.tsx
+++ b/src/app/user/[id]/setting/edit/components/EditBirthDate/EditBirthDate.tsx
@@ -11,18 +11,18 @@ interface EditAgeProps {
   errors: FieldErrors<UserEditData>;
 }
 
-const EditBirthDay = ({ register, errors }: EditAgeProps) => {
+const EditBirthDate = ({ register, errors }: EditAgeProps) => {
   return (
     <GS.UserEditSectionContainer>
       <UserEditInput
         title={"나이"}
         inputType={"date"}
-        placeholder={USER_EDIT_PLACEHOLDER.BIRTHDAY}
-        register={register("birthDay", validation_user.birthDay)}
-        errorsMessage={errors.birthDay && errors.birthDay.message}
+        placeholder={USER_EDIT_PLACEHOLDER.BIRTH_DATE}
+        register={register("birthDate", validation_user.birthDate)}
+        errorsMessage={errors.birthDate && errors.birthDate.message}
       />
     </GS.UserEditSectionContainer>
   );
 };
 
-export default EditBirthDay;
+export default EditBirthDate;

--- a/src/app/user/[id]/setting/edit/components/EditBirthDay/EditBirthDay.tsx
+++ b/src/app/user/[id]/setting/edit/components/EditBirthDay/EditBirthDay.tsx
@@ -1,0 +1,28 @@
+import * as GS from "../../UserEdit.styles";
+
+import { FieldErrors, UseFormRegister } from "react-hook-form";
+import { UserEditData } from "../../UserEdit.types";
+import { USER_EDIT_PLACEHOLDER } from "../../UserEdit.constants";
+import { UserEditInput } from "..";
+import { validation_user } from "@/constants/userValidate";
+
+interface EditAgeProps {
+  register: UseFormRegister<UserEditData>;
+  errors: FieldErrors<UserEditData>;
+}
+
+const EditBirthDay = ({ register, errors }: EditAgeProps) => {
+  return (
+    <GS.UserEditSectionContainer>
+      <UserEditInput
+        title={"나이"}
+        inputType={"date"}
+        placeholder={USER_EDIT_PLACEHOLDER.BIRTHDAY}
+        register={register("birthDay", validation_user.birthDay)}
+        errorsMessage={errors.birthDay && errors.birthDay.message}
+      />
+    </GS.UserEditSectionContainer>
+  );
+};
+
+export default EditBirthDay;

--- a/src/app/user/[id]/setting/edit/components/EditBodyInfo/EditBodyInfo.styles.ts
+++ b/src/app/user/[id]/setting/edit/components/EditBodyInfo/EditBodyInfo.styles.ts
@@ -1,0 +1,12 @@
+import styled from "styled-components";
+
+export const EditBodyInfoLayout = styled.div`
+  width: 100%;
+
+  display: flex;
+  gap: 2rem;
+`;
+
+export const EditBodyInfoContainer = styled.div`
+  width: 50%;
+`;

--- a/src/app/user/[id]/setting/edit/components/EditBodyInfo/EditBodyInfo.tsx
+++ b/src/app/user/[id]/setting/edit/components/EditBodyInfo/EditBodyInfo.tsx
@@ -1,0 +1,40 @@
+import * as S from "./EditBodyInfo.styles";
+
+import { FieldErrors, UseFormRegister } from "react-hook-form";
+import { UserEditData } from "../../UserEdit.types";
+import { USER_EDIT_PLACEHOLDER } from "../../UserEdit.constants";
+import { UserEditInput } from "..";
+import { validation_user } from "@/constants/userValidate";
+
+interface EditBodyInfoProps {
+  register: UseFormRegister<UserEditData>;
+  errors: FieldErrors<UserEditData>;
+}
+
+const EditBodyInfo = ({ register, errors }: EditBodyInfoProps) => {
+  return (
+    <S.EditBodyInfoLayout>
+      <S.EditBodyInfoContainer>
+        <UserEditInput
+          title={"키"}
+          inputType={"number"}
+          placeholder={USER_EDIT_PLACEHOLDER.HEIGHT}
+          errorsMessage={errors.height && errors.height.message}
+          register={register("height", validation_user.height)}
+        />
+      </S.EditBodyInfoContainer>
+
+      <S.EditBodyInfoContainer>
+        <UserEditInput
+          title={"몸무게"}
+          inputType={"number"}
+          placeholder={USER_EDIT_PLACEHOLDER.WEIGHT}
+          errorsMessage={errors.weight && errors.weight.message}
+          register={register("weight", validation_user.weight)}
+        />
+      </S.EditBodyInfoContainer>
+    </S.EditBodyInfoLayout>
+  );
+};
+
+export default EditBodyInfo;

--- a/src/app/user/[id]/setting/edit/components/EditIntensity/EditIntensity.styles.ts
+++ b/src/app/user/[id]/setting/edit/components/EditIntensity/EditIntensity.styles.ts
@@ -1,0 +1,73 @@
+import { DISPLAY_NONE_SCROLLBAR, FONT_SIZE, FONT_WEIGHT } from "@/styles/theme";
+import styled from "styled-components";
+
+export const IntensityTitle = styled.h6`
+  padding-left: 0.6rem;
+  margin-bottom: 1.2rem;
+
+  font-size: ${FONT_SIZE.H5};
+  font-weight: ${FONT_WEIGHT.BOLD};
+
+  user-select: none;
+`;
+
+export const IntensityDescription = styled.p`
+  padding-left: 0.6rem;
+  margin-bottom: 3rem;
+
+  font-size: ${FONT_SIZE.MEDIUM};
+  font-weight: ${FONT_WEIGHT.REGULAR};
+
+  user-select: none;
+`;
+
+export const IntensityOptionList = styled.ul`
+  width: 100%;
+  margin-bottom: 2.8rem;
+
+  display: flex;
+  flex-direction: column;
+  gap: 1.2rem;
+
+  user-select: none;
+`;
+
+export const IntensityItemContainer = styled.li`
+  width: 100%;
+
+  list-style: none;
+`;
+
+export const IntensityItemLabel = styled.label`
+  width: 100%;
+
+  display: flex;
+  align-items: center;
+  gap: 1.6rem;
+
+  cursor: pointer;
+`;
+
+export const IntensityItemCircle = styled.i<{ $isSelected: boolean }>`
+  min-height: 3rem;
+  min-width: 3rem;
+
+  display: flex;
+  align-items: center;
+  justify-content: center;
+
+  background-color: ${({ theme, $isSelected }) =>
+    $isSelected ? theme.green_500 : theme.transparent_10};
+  border-radius: 50%;
+`;
+
+export const IntensityOptionDescription = styled.p`
+  flex-grow: 1;
+
+  font-size: ${FONT_SIZE.LARGE};
+  font-weight: ${FONT_WEIGHT.MEDIUM};
+  white-space: nowrap;
+  overflow: scroll;
+
+  ${DISPLAY_NONE_SCROLLBAR}
+`;

--- a/src/app/user/[id]/setting/edit/components/EditIntensity/EditIntensity.tsx
+++ b/src/app/user/[id]/setting/edit/components/EditIntensity/EditIntensity.tsx
@@ -3,12 +3,13 @@ import * as GS from "../../UserEdit.styles";
 import * as S from "./EditIntensity.styles";
 import useTheme from "@/lib/hooks/useTheme";
 import { UseFormRegister, UseFormRegisterReturn } from "react-hook-form";
-import { IntensityType, UserEditData } from "../../UserEdit.types";
+import { UserEditData } from "../../UserEdit.types";
 import { INTENSITY_OPTIONS } from "@/constants/variable";
+import { IntensityOption } from "@/types/OriginDataType";
 
 interface EditIntensityProps {
   register: UseFormRegister<UserEditData>;
-  selectedIntensity: IntensityType;
+  selectedIntensity: IntensityOption;
 }
 
 const EditIntensity = ({ register, selectedIntensity }: EditIntensityProps) => {
@@ -47,10 +48,6 @@ interface IntensityItemProps {
 const IntensityItem = ({ isSelected, value, optionDescription, register }: IntensityItemProps) => {
   const theme = useTheme();
 
-  if (!theme) {
-    return;
-  }
-
   return (
     <S.IntensityItemContainer>
       <input
@@ -64,7 +61,7 @@ const IntensityItem = ({ isSelected, value, optionDescription, register }: Inten
         <S.IntensityItemCircle $isSelected={isSelected}>
           <Check
             className={`w-6 h-6 mx-auto my-auto transition-colors`}
-            stroke={isSelected ? theme.white_100 : theme.gray_300}
+            stroke={isSelected ? theme?.white_100 : theme?.gray_300}
             strokeWidth={3.5}
           />
         </S.IntensityItemCircle>

--- a/src/app/user/[id]/setting/edit/components/EditIntensity/EditIntensity.tsx
+++ b/src/app/user/[id]/setting/edit/components/EditIntensity/EditIntensity.tsx
@@ -1,0 +1,75 @@
+import { Check } from "@/components/icons";
+import * as GS from "../../UserEdit.styles";
+import * as S from "./EditIntensity.styles";
+import useTheme from "@/lib/hooks/useTheme";
+import { UseFormRegister, UseFormRegisterReturn } from "react-hook-form";
+import { IntensityType, UserEditData } from "../../UserEdit.types";
+import { INTENSITY_OPTIONS } from "@/constants/variable";
+
+interface EditIntensityProps {
+  register: UseFormRegister<UserEditData>;
+  selectedIntensity: IntensityType;
+}
+
+const EditIntensity = ({ register, selectedIntensity }: EditIntensityProps) => {
+  return (
+    <GS.UserEditSectionContainer>
+      <S.IntensityTitle>평소 운동 강도</S.IntensityTitle>
+      <S.IntensityDescription>
+        기초 대사량 계산에 필요한 활동 계수를 설정해요.
+      </S.IntensityDescription>
+
+      <S.IntensityOptionList>
+        {INTENSITY_OPTIONS.map(({ label, value }) => (
+          <IntensityItem
+            key={value}
+            value={value}
+            optionDescription={label}
+            isSelected={selectedIntensity === value}
+            register={register("intensity")}
+          />
+        ))}
+      </S.IntensityOptionList>
+    </GS.UserEditSectionContainer>
+  );
+};
+
+export default EditIntensity;
+
+interface IntensityItemProps {
+  key?: string | number;
+  value: string;
+  optionDescription: string;
+  isSelected: boolean;
+  register: UseFormRegisterReturn;
+}
+
+const IntensityItem = ({ isSelected, value, optionDescription, register }: IntensityItemProps) => {
+  const theme = useTheme();
+
+  if (!theme) {
+    return;
+  }
+
+  return (
+    <S.IntensityItemContainer>
+      <input
+        id={`intensity_${value}`}
+        type="radio"
+        style={{ display: "none" }}
+        value={value}
+        {...register}
+      />
+      <S.IntensityItemLabel htmlFor={`intensity_${value}`}>
+        <S.IntensityItemCircle $isSelected={isSelected}>
+          <Check
+            className={`w-6 h-6 mx-auto my-auto transition-colors`}
+            stroke={isSelected ? theme.white_100 : theme.gray_300}
+            strokeWidth={3.5}
+          />
+        </S.IntensityItemCircle>
+        <S.IntensityOptionDescription>{optionDescription}</S.IntensityOptionDescription>
+      </S.IntensityItemLabel>
+    </S.IntensityItemContainer>
+  );
+};

--- a/src/app/user/[id]/setting/edit/components/EditNickname/EditNickname.styles.ts
+++ b/src/app/user/[id]/setting/edit/components/EditNickname/EditNickname.styles.ts
@@ -1,0 +1,26 @@
+import { DISPLAY_NONE_SCROLLBAR } from "@/styles/theme";
+import styled from "styled-components";
+
+export const EditNickNameContainer = styled.div`
+  width: 100%;
+`;
+
+export const EditNicknameActions = styled.div`
+  display: flex;
+  gap: 1rem;
+`;
+
+export const EditNicknameWarningWrapper = styled.div`
+  width: 100%;
+  height: 2.4rem;
+  padding-left: 0.6rem;
+
+  display: flex;
+  align-items: center;
+
+  white-space: nowrap;
+
+  overflow: scroll;
+
+  ${DISPLAY_NONE_SCROLLBAR}
+`;

--- a/src/app/user/[id]/setting/edit/components/EditNickname/EditNickname.tsx
+++ b/src/app/user/[id]/setting/edit/components/EditNickname/EditNickname.tsx
@@ -1,19 +1,22 @@
 import * as S from "./EditNickname.styles";
 import * as GS from "../../UserEdit.styles";
 
-import { UseFormRegister } from "react-hook-form";
+import { FieldErrors, UseFormRegister } from "react-hook-form";
 import { UserEditData } from "../../UserEdit.types";
 import { Button, Input, InputLabel } from "@/components";
 import useTheme from "@/lib/hooks/useTheme";
 import { FONT_WEIGHT } from "@/styles/theme";
+import { USER_EDIT_ERROR_MESSAGE } from "../../UserEdit.constants";
+import { USER_VALIDATE } from "@/constants/userValidate";
 
 interface EditNicknameProps {
   register: UseFormRegister<UserEditData>;
+  errors: FieldErrors<UserEditData>;
 
   onChangeNickname: () => void;
 }
 
-const EditNickname = ({ register, onChangeNickname }: EditNicknameProps) => {
+const EditNickname = ({ register, onChangeNickname, errors }: EditNicknameProps) => {
   const theme = useTheme();
 
   if (!theme) {
@@ -26,9 +29,15 @@ const EditNickname = ({ register, onChangeNickname }: EditNicknameProps) => {
       <S.EditNicknameActions>
         <Input
           register={register("nickname", {
-            required: "변경하실 닉네임을 입력해주세요.",
-            minLength: { message: "2글자 이상을 입력해 주세요.", value: 2 },
-            maxLength: { message: " 10글자 이하로 입력해 주세요.", value: 10 },
+            required: USER_EDIT_ERROR_MESSAGE.NICKNAME.REQUIRE,
+            minLength: {
+              message: USER_EDIT_ERROR_MESSAGE.NICKNAME.MIN_LENGTH,
+              value: USER_VALIDATE.NICKNAME.MIN_LENGTH,
+            },
+            maxLength: {
+              message: USER_EDIT_ERROR_MESSAGE.NICKNAME.MAX_LENGTH,
+              value: USER_VALIDATE.NICKNAME.MAX_LENGTH,
+            },
           })}
           type="text"
           placeholder="수정하실 닉네임을 입력해주세요!"
@@ -48,10 +57,12 @@ const EditNickname = ({ register, onChangeNickname }: EditNicknameProps) => {
       </S.EditNicknameActions>
 
       <S.EditNicknameWarningWrapper>
-        <InputLabel
-          text="이것은 경고 문자"
-          type="danger"
-        />
+        {errors.nickname && (
+          <InputLabel
+            text={errors.nickname.message}
+            type="danger"
+          />
+        )}
       </S.EditNicknameWarningWrapper>
     </S.EditNickNameContainer>
   );

--- a/src/app/user/[id]/setting/edit/components/EditNickname/EditNickname.tsx
+++ b/src/app/user/[id]/setting/edit/components/EditNickname/EditNickname.tsx
@@ -1,0 +1,26 @@
+import { UseFormRegister } from "react-hook-form";
+import { UserEditData } from "../../UserEdit.types";
+import { Input } from "@/components";
+
+interface EditNicknameProps {
+  register: UseFormRegister<UserEditData>;
+
+  onChangeNickname: () => void;
+}
+
+const EditNickname = ({ register, onChangeNickname }: EditNicknameProps) => {
+  return (
+    <Input
+      register={register("nickname", {
+        required: "변경하실 닉네임을 입력해주세요.",
+        minLength: { message: "2글자 이상을 입력해 주세요.", value: 2 },
+        maxLength: { message: " 10글자 이하로 입력해 주세요.", value: 10 },
+      })}
+      type="text"
+      placeholder="수정하실 닉네임을 입력해주세요!"
+      onChange={onChangeNickname}
+    />
+  );
+};
+
+export default EditNickname;

--- a/src/app/user/[id]/setting/edit/components/EditNickname/EditNickname.tsx
+++ b/src/app/user/[id]/setting/edit/components/EditNickname/EditNickname.tsx
@@ -8,6 +8,7 @@ import useTheme from "@/lib/hooks/useTheme";
 import { FONT_WEIGHT } from "@/styles/theme";
 import { USER_EDIT_ERROR_MESSAGE } from "../../UserEdit.constants";
 import { USER_VALIDATE } from "@/constants/userValidate";
+import { MouseEvent } from "react";
 
 interface EditNicknameProps {
   register: UseFormRegister<UserEditData>;
@@ -22,6 +23,12 @@ const EditNickname = ({ register, onChangeNickname, errors }: EditNicknameProps)
   if (!theme) {
     return;
   }
+
+  const handleClick = (e: MouseEvent<HTMLButtonElement>) => {
+    e.preventDefault();
+
+    console.log("dd");
+  };
   return (
     <S.EditNickNameContainer>
       <GS.UserEditTitle>닉네임</GS.UserEditTitle>
@@ -48,9 +55,10 @@ const EditNickname = ({ register, onChangeNickname, errors }: EditNicknameProps)
           width={"16rem"}
           buttonColor={theme.green_500}
           textColor={theme.text_secondary_color}
-          useRipple={true}
+          useRipple
           rippleColor={theme.text_secondary_color + 50}
           style={{ whiteSpace: "nowrap", fontWeight: FONT_WEIGHT.SEMIBOLD, userSelect: "none" }}
+          onClickHandler={handleClick}
         >
           중복 확인
         </Button>

--- a/src/app/user/[id]/setting/edit/components/EditNickname/EditNickname.tsx
+++ b/src/app/user/[id]/setting/edit/components/EditNickname/EditNickname.tsx
@@ -6,8 +6,8 @@ import { UserEditData } from "../../UserEdit.types";
 import { Button, Input, InputLabel } from "@/components";
 import useTheme from "@/lib/hooks/useTheme";
 import { FONT_SIZE, FONT_WEIGHT } from "@/styles/theme";
-import { USER_EDIT_ERROR_MESSAGE } from "../../UserEdit.constants";
-import { USER_VALIDATE } from "@/constants/userValidate";
+import { USER_EDIT_PLACEHOLDER } from "../../UserEdit.constants";
+import { validation_user } from "@/constants/userValidate";
 import { MouseEvent } from "react";
 
 interface EditNicknameProps {
@@ -37,24 +37,14 @@ const EditNickname = ({
   };
 
   return (
-    <S.EditNickNameContainer>
+    <GS.UserEditSectionContainer>
       <GS.UserEditTitle>닉네임</GS.UserEditTitle>
 
       <S.EditNicknameActions>
         <Input
           type="text"
-          register={register("nickname", {
-            required: USER_EDIT_ERROR_MESSAGE.NICKNAME.REQUIRE,
-            minLength: {
-              message: USER_EDIT_ERROR_MESSAGE.NICKNAME.MIN_LENGTH,
-              value: USER_VALIDATE.NICKNAME.MIN_LENGTH,
-            },
-            maxLength: {
-              message: USER_EDIT_ERROR_MESSAGE.NICKNAME.MAX_LENGTH,
-              value: USER_VALIDATE.NICKNAME.MAX_LENGTH,
-            },
-          })}
-          placeholder="수정하실 닉네임을 입력해주세요!"
+          register={register("nickname", validation_user.nickname)}
+          placeholder={USER_EDIT_PLACEHOLDER.NICKNAME}
           style={{
             lineHeight: "2rem",
             width: "100%",
@@ -82,15 +72,15 @@ const EditNickname = ({
         </Button>
       </S.EditNicknameActions>
 
-      <S.EditNicknameWarningWrapper>
+      <GS.UserEditWarning>
         {errors.nickname && (
           <InputLabel
             text={errors.nickname.message}
             type="danger"
           />
         )}
-      </S.EditNicknameWarningWrapper>
-    </S.EditNickNameContainer>
+      </GS.UserEditWarning>
+    </GS.UserEditSectionContainer>
   );
 };
 

--- a/src/app/user/[id]/setting/edit/components/EditNickname/EditNickname.tsx
+++ b/src/app/user/[id]/setting/edit/components/EditNickname/EditNickname.tsx
@@ -1,11 +1,11 @@
 import * as S from "./EditNickname.styles";
 import * as GS from "../../UserEdit.styles";
 
-import { FieldErrors, UseFormGetValues, UseFormRegister } from "react-hook-form";
+import { FieldErrors, UseFormRegister } from "react-hook-form";
 import { UserEditData } from "../../UserEdit.types";
 import { Button, Input, InputLabel } from "@/components";
 import useTheme from "@/lib/hooks/useTheme";
-import { FONT_WEIGHT } from "@/styles/theme";
+import { FONT_SIZE, FONT_WEIGHT } from "@/styles/theme";
 import { USER_EDIT_ERROR_MESSAGE } from "../../UserEdit.constants";
 import { USER_VALIDATE } from "@/constants/userValidate";
 import { MouseEvent } from "react";
@@ -55,6 +55,12 @@ const EditNickname = ({
           })}
           type="text"
           placeholder="수정하실 닉네임을 입력해주세요!"
+          style={{
+            lineHeight: "2rem",
+            width: "100%",
+            fontSize: "1.5rem",
+            fontWeight: FONT_WEIGHT.SEMIBOLD,
+          }}
         />
 
         <Button
@@ -63,7 +69,12 @@ const EditNickname = ({
           textColor={theme.text_secondary_color}
           useRipple
           rippleColor={theme.text_secondary_color + 50}
-          style={{ whiteSpace: "nowrap", fontWeight: FONT_WEIGHT.SEMIBOLD, userSelect: "none" }}
+          style={{
+            whiteSpace: "nowrap",
+            fontSize: FONT_SIZE.H5,
+            fontWeight: FONT_WEIGHT.SEMIBOLD,
+            userSelect: "none",
+          }}
           onClickHandler={handleClick}
           disabled={isCheckedNickname}
         >

--- a/src/app/user/[id]/setting/edit/components/EditNickname/EditNickname.tsx
+++ b/src/app/user/[id]/setting/edit/components/EditNickname/EditNickname.tsx
@@ -27,10 +27,6 @@ const EditNickname = ({
 }: EditNicknameProps) => {
   const theme = useTheme();
 
-  if (!theme) {
-    return;
-  }
-
   const handleClick = (e: MouseEvent<HTMLButtonElement>) => {
     e.preventDefault();
     onCheckSameNickname();
@@ -55,10 +51,10 @@ const EditNickname = ({
 
         <Button
           width={"16rem"}
-          buttonColor={theme.green_500}
-          textColor={theme.text_secondary_color}
+          buttonColor={theme?.green_500}
+          textColor={theme?.text_secondary_color}
           useRipple
-          rippleColor={theme.text_secondary_color + 50}
+          rippleColor={theme?.text_secondary_color + 50}
           style={{
             whiteSpace: "nowrap",
             fontSize: FONT_SIZE.H5,

--- a/src/app/user/[id]/setting/edit/components/EditNickname/EditNickname.tsx
+++ b/src/app/user/[id]/setting/edit/components/EditNickname/EditNickname.tsx
@@ -1,6 +1,11 @@
+import * as S from "./EditNickname.styles";
+import * as GS from "../../UserEdit.styles";
+
 import { UseFormRegister } from "react-hook-form";
 import { UserEditData } from "../../UserEdit.types";
-import { Input } from "@/components";
+import { Button, Input, InputLabel } from "@/components";
+import useTheme from "@/lib/hooks/useTheme";
+import { FONT_WEIGHT } from "@/styles/theme";
 
 interface EditNicknameProps {
   register: UseFormRegister<UserEditData>;
@@ -9,17 +14,46 @@ interface EditNicknameProps {
 }
 
 const EditNickname = ({ register, onChangeNickname }: EditNicknameProps) => {
+  const theme = useTheme();
+
+  if (!theme) {
+    return;
+  }
   return (
-    <Input
-      register={register("nickname", {
-        required: "변경하실 닉네임을 입력해주세요.",
-        minLength: { message: "2글자 이상을 입력해 주세요.", value: 2 },
-        maxLength: { message: " 10글자 이하로 입력해 주세요.", value: 10 },
-      })}
-      type="text"
-      placeholder="수정하실 닉네임을 입력해주세요!"
-      onChange={onChangeNickname}
-    />
+    <S.EditNickNameContainer>
+      <GS.UserEditTitle>닉네임</GS.UserEditTitle>
+
+      <S.EditNicknameActions>
+        <Input
+          register={register("nickname", {
+            required: "변경하실 닉네임을 입력해주세요.",
+            minLength: { message: "2글자 이상을 입력해 주세요.", value: 2 },
+            maxLength: { message: " 10글자 이하로 입력해 주세요.", value: 10 },
+          })}
+          type="text"
+          placeholder="수정하실 닉네임을 입력해주세요!"
+          onChange={onChangeNickname}
+        />
+
+        <Button
+          width={"16rem"}
+          buttonColor={theme.green_500}
+          textColor={theme.text_secondary_color}
+          useRipple={true}
+          rippleColor={theme.text_secondary_color + 50}
+          style={{ whiteSpace: "nowrap", fontWeight: FONT_WEIGHT.SEMIBOLD, userSelect: "none" }}
+        >
+          중복 확인
+        </Button>
+      </S.EditNicknameActions>
+
+      <S.EditNicknameWarningWrapper>
+        <InputLabel
+          text="이것은 경고 문자"
+          type="danger"
+        />
+      </S.EditNicknameWarningWrapper>
+    </S.EditNickNameContainer>
   );
 };
 

--- a/src/app/user/[id]/setting/edit/components/EditNickname/EditNickname.tsx
+++ b/src/app/user/[id]/setting/edit/components/EditNickname/EditNickname.tsx
@@ -1,7 +1,7 @@
 import * as S from "./EditNickname.styles";
 import * as GS from "../../UserEdit.styles";
 
-import { FieldErrors, UseFormRegister } from "react-hook-form";
+import { FieldErrors, UseFormGetValues, UseFormRegister } from "react-hook-form";
 import { UserEditData } from "../../UserEdit.types";
 import { Button, Input, InputLabel } from "@/components";
 import useTheme from "@/lib/hooks/useTheme";
@@ -14,10 +14,19 @@ interface EditNicknameProps {
   register: UseFormRegister<UserEditData>;
   errors: FieldErrors<UserEditData>;
 
+  isCheckedNickname: boolean;
+  onCheckSameNickname: () => void;
   onChangeNickname: () => void;
 }
 
-const EditNickname = ({ register, onChangeNickname, errors }: EditNicknameProps) => {
+const EditNickname = ({
+  register,
+  errors,
+
+  isCheckedNickname,
+  onChangeNickname,
+  onCheckSameNickname,
+}: EditNicknameProps) => {
   const theme = useTheme();
 
   if (!theme) {
@@ -26,9 +35,9 @@ const EditNickname = ({ register, onChangeNickname, errors }: EditNicknameProps)
 
   const handleClick = (e: MouseEvent<HTMLButtonElement>) => {
     e.preventDefault();
-
-    console.log("dd");
+    onCheckSameNickname();
   };
+
   return (
     <S.EditNickNameContainer>
       <GS.UserEditTitle>닉네임</GS.UserEditTitle>
@@ -59,6 +68,7 @@ const EditNickname = ({ register, onChangeNickname, errors }: EditNicknameProps)
           rippleColor={theme.text_secondary_color + 50}
           style={{ whiteSpace: "nowrap", fontWeight: FONT_WEIGHT.SEMIBOLD, userSelect: "none" }}
           onClickHandler={handleClick}
+          disabled={isCheckedNickname}
         >
           중복 확인
         </Button>

--- a/src/app/user/[id]/setting/edit/components/EditNickname/EditNickname.tsx
+++ b/src/app/user/[id]/setting/edit/components/EditNickname/EditNickname.tsx
@@ -42,6 +42,7 @@ const EditNickname = ({
 
       <S.EditNicknameActions>
         <Input
+          type="text"
           register={register("nickname", {
             required: USER_EDIT_ERROR_MESSAGE.NICKNAME.REQUIRE,
             minLength: {
@@ -53,7 +54,6 @@ const EditNickname = ({
               value: USER_VALIDATE.NICKNAME.MAX_LENGTH,
             },
           })}
-          type="text"
           placeholder="수정하실 닉네임을 입력해주세요!"
           style={{
             lineHeight: "2rem",

--- a/src/app/user/[id]/setting/edit/components/EditNickname/EditNickname.tsx
+++ b/src/app/user/[id]/setting/edit/components/EditNickname/EditNickname.tsx
@@ -16,7 +16,6 @@ interface EditNicknameProps {
 
   isCheckedNickname: boolean;
   onCheckSameNickname: () => void;
-  onChangeNickname: () => void;
 }
 
 const EditNickname = ({
@@ -24,7 +23,6 @@ const EditNickname = ({
   errors,
 
   isCheckedNickname,
-  onChangeNickname,
   onCheckSameNickname,
 }: EditNicknameProps) => {
   const theme = useTheme();
@@ -57,7 +55,6 @@ const EditNickname = ({
           })}
           type="text"
           placeholder="수정하실 닉네임을 입력해주세요!"
-          onChange={onChangeNickname}
         />
 
         <Button

--- a/src/app/user/[id]/setting/edit/components/EditSex/EditSex.styles.ts
+++ b/src/app/user/[id]/setting/edit/components/EditSex/EditSex.styles.ts
@@ -5,6 +5,8 @@ export const EditSexContainer = styled.div`
 `;
 
 export const EditSexActions = styled.div`
+  margin-bottom: 2.4rem;
+
   display: flex;
   gap: 2rem;
 `;

--- a/src/app/user/[id]/setting/edit/components/EditSex/EditSex.styles.ts
+++ b/src/app/user/[id]/setting/edit/components/EditSex/EditSex.styles.ts
@@ -1,13 +1,13 @@
 import { FONT_SIZE, FONT_WEIGHT } from "@/styles/theme";
 import styled from "styled-components";
 
-export const EditAgeContainer = styled.div`
+export const EditSexContainer = styled.div`
   width: 100%;
 
   border: 1px solid red;
 `;
 
-export const EditAgeActions = styled.div`
+export const EditSexActions = styled.div`
   display: flex;
   gap: 2rem;
 `;

--- a/src/app/user/[id]/setting/edit/components/EditSex/EditSex.styles.ts
+++ b/src/app/user/[id]/setting/edit/components/EditSex/EditSex.styles.ts
@@ -1,6 +1,4 @@
-import { FONT_SIZE, FONT_WEIGHT } from "@/styles/theme";
 import styled from "styled-components";
-import { theme } from "twin.macro";
 
 export const EditSexContainer = styled.div`
   width: 100%;
@@ -9,26 +7,4 @@ export const EditSexContainer = styled.div`
 export const EditSexActions = styled.div`
   display: flex;
   gap: 2rem;
-`;
-
-export const InputRadioLabel = styled.label<{ $isSelected: boolean }>`
-  padding: 1.5rem;
-  width: 100%;
-
-  display: flex;
-  align-items: center;
-  justify-content: center;
-
-  border-radius: 0.8rem;
-  background-color: ${({ theme, $isSelected }) =>
-    $isSelected ? theme.green_500 : theme.transparent_10};
-
-  font-size: ${FONT_SIZE.H5};
-  font-weight: ${FONT_WEIGHT.BOLD};
-  letter-spacing: 1px;
-  white-space: nowrap;
-  color: ${({ theme, $isSelected }) => ($isSelected ? theme.text_secondary_color : theme.gray_300)};
-
-  user-select: none;
-  cursor: pointer;
 `;

--- a/src/app/user/[id]/setting/edit/components/EditSex/EditSex.styles.ts
+++ b/src/app/user/[id]/setting/edit/components/EditSex/EditSex.styles.ts
@@ -1,10 +1,9 @@
 import { FONT_SIZE, FONT_WEIGHT } from "@/styles/theme";
 import styled from "styled-components";
+import { theme } from "twin.macro";
 
 export const EditSexContainer = styled.div`
   width: 100%;
-
-  border: 1px solid red;
 `;
 
 export const EditSexActions = styled.div`
@@ -28,7 +27,7 @@ export const InputRadioLabel = styled.label<{ $isSelected: boolean }>`
   font-weight: ${FONT_WEIGHT.BOLD};
   letter-spacing: 1px;
   white-space: nowrap;
-  color: ${({ theme }) => theme.text_secondary_color};
+  color: ${({ theme, $isSelected }) => ($isSelected ? theme.text_secondary_color : theme.gray_300)};
 
   user-select: none;
   cursor: pointer;

--- a/src/app/user/[id]/setting/edit/components/EditSex/EditSex.styles.ts
+++ b/src/app/user/[id]/setting/edit/components/EditSex/EditSex.styles.ts
@@ -21,13 +21,15 @@ export const InputRadioLabel = styled.label<{ $isSelected: boolean }>`
   justify-content: center;
 
   border-radius: 0.8rem;
+  background-color: ${({ theme, $isSelected }) =>
+    $isSelected ? theme.green_500 : theme.transparent_10};
 
-  font-size: ${FONT_SIZE.LARGE};
+  font-size: ${FONT_SIZE.H5};
   font-weight: ${FONT_WEIGHT.BOLD};
   letter-spacing: 1px;
   white-space: nowrap;
+  color: ${({ theme }) => theme.text_secondary_color};
 
   user-select: none;
-
-  border: 1px solid red;
+  cursor: pointer;
 `;

--- a/src/app/user/[id]/setting/edit/components/EditSex/EditSex.styles.ts
+++ b/src/app/user/[id]/setting/edit/components/EditSex/EditSex.styles.ts
@@ -1,9 +1,5 @@
 import styled from "styled-components";
 
-export const EditSexContainer = styled.div`
-  width: 100%;
-`;
-
 export const EditSexActions = styled.div`
   margin-bottom: 2.4rem;
 

--- a/src/app/user/[id]/setting/edit/components/EditSex/EditSex.tsx
+++ b/src/app/user/[id]/setting/edit/components/EditSex/EditSex.tsx
@@ -1,7 +1,8 @@
-import { UseFormRegister, UseFormRegisterReturn } from "react-hook-form";
+import { UseFormRegister } from "react-hook-form";
 import * as GS from "../../UserEdit.styles";
 import * as S from "./EditSex.styles";
 import { UserEditData } from "../../UserEdit.types";
+import { InputRadio } from "@/components";
 interface EditAgeProps {
   register: UseFormRegister<UserEditData>;
   selectedSex: string;
@@ -32,31 +33,3 @@ const EditSex = ({ register, selectedSex }: EditAgeProps) => {
 };
 
 export default EditSex;
-
-interface createInputRadioProps {
-  register: UseFormRegisterReturn;
-  value: string | number;
-  text: string;
-  isSelected: boolean;
-  key?: string | number;
-}
-const InputRadio = ({ value, text, register, isSelected }: createInputRadioProps) => {
-  return (
-    <>
-      <input
-        type="radio"
-        id={`${text}_${value}`}
-        value={value}
-        style={{ display: "none" }}
-        {...register}
-      />
-
-      <S.InputRadioLabel
-        htmlFor={`${text}_${value}`}
-        $isSelected={isSelected}
-      >
-        {text}
-      </S.InputRadioLabel>
-    </>
-  );
-};

--- a/src/app/user/[id]/setting/edit/components/EditSex/EditSex.tsx
+++ b/src/app/user/[id]/setting/edit/components/EditSex/EditSex.tsx
@@ -3,10 +3,12 @@ import * as GS from "../../UserEdit.styles";
 import * as S from "./EditSex.styles";
 import { UserEditData } from "../../UserEdit.types";
 import { InputRadio } from "@/components";
+
 interface EditAgeProps {
   register: UseFormRegister<UserEditData>;
   selectedSex: string;
 }
+
 const EditSex = ({ register, selectedSex }: EditAgeProps) => {
   const options = [
     { text: "남성", value: "male" },

--- a/src/app/user/[id]/setting/edit/components/EditSex/EditSex.tsx
+++ b/src/app/user/[id]/setting/edit/components/EditSex/EditSex.tsx
@@ -1,6 +1,7 @@
-import { UseFormRegister } from "react-hook-form";
 import * as GS from "../../UserEdit.styles";
 import * as S from "./EditSex.styles";
+
+import { UseFormRegister } from "react-hook-form";
 import { UserEditData } from "../../UserEdit.types";
 import { InputRadio } from "@/components";
 
@@ -16,7 +17,7 @@ const EditSex = ({ register, selectedSex }: EditAgeProps) => {
   ];
 
   return (
-    <S.EditSexContainer>
+    <GS.UserEditSectionContainer>
       <GS.UserEditTitle>성별</GS.UserEditTitle>
 
       <S.EditSexActions>
@@ -26,11 +27,11 @@ const EditSex = ({ register, selectedSex }: EditAgeProps) => {
             value={value}
             text={text}
             isSelected={selectedSex === value}
-            register={register("sex", { required: "성별의 입력은 필수" })}
+            register={register("sex")}
           />
         ))}
       </S.EditSexActions>
-    </S.EditSexContainer>
+    </GS.UserEditSectionContainer>
   );
 };
 

--- a/src/app/user/[id]/setting/edit/components/EditSex/EditSex.tsx
+++ b/src/app/user/[id]/setting/edit/components/EditSex/EditSex.tsx
@@ -4,6 +4,7 @@ import * as S from "./EditSex.styles";
 import { UseFormRegister } from "react-hook-form";
 import { UserEditData } from "../../UserEdit.types";
 import { InputRadio } from "@/components";
+import { SEX_OPTIONS } from "@/constants/variable";
 
 interface EditAgeProps {
   register: UseFormRegister<UserEditData>;
@@ -11,21 +12,16 @@ interface EditAgeProps {
 }
 
 const EditSex = ({ register, selectedSex }: EditAgeProps) => {
-  const options = [
-    { text: "남성", value: "male" },
-    { text: "여성", value: "female" },
-  ];
-
   return (
     <GS.UserEditSectionContainer>
       <GS.UserEditTitle>성별</GS.UserEditTitle>
 
       <S.EditSexActions>
-        {options.map(({ text, value }) => (
+        {SEX_OPTIONS.map(({ label, value }) => (
           <InputRadio
-            key={`${text}_${value}`}
+            key={`${label}_${value}`}
             value={value}
-            text={text}
+            text={label}
             isSelected={selectedSex === value}
             register={register("sex")}
           />

--- a/src/app/user/[id]/setting/edit/components/EditSex/EditSex.tsx
+++ b/src/app/user/[id]/setting/edit/components/EditSex/EditSex.tsx
@@ -4,8 +4,9 @@ import * as S from "./EditSex.styles";
 import { UserEditData } from "../../UserEdit.types";
 interface EditAgeProps {
   register: UseFormRegister<UserEditData>;
+  selectedSex: string;
 }
-const EditSex = ({ register }: EditAgeProps) => {
+const EditSex = ({ register, selectedSex }: EditAgeProps) => {
   const options = [
     { text: "남성", value: "male" },
     { text: "여성", value: "female" },
@@ -21,7 +22,7 @@ const EditSex = ({ register }: EditAgeProps) => {
             key={`${text}_${value}`}
             value={value}
             text={text}
-            isSelected={true}
+            isSelected={selectedSex === value}
             register={register("sex", { required: "성별의 입력은 필수" })}
           />
         ))}

--- a/src/app/user/[id]/setting/edit/components/EditSex/EditSex.tsx
+++ b/src/app/user/[id]/setting/edit/components/EditSex/EditSex.tsx
@@ -1,35 +1,36 @@
 import { UseFormRegister, UseFormRegisterReturn } from "react-hook-form";
 import * as GS from "../../UserEdit.styles";
-import * as S from "./EditAge.styles";
+import * as S from "./EditSex.styles";
 import { UserEditData } from "../../UserEdit.types";
 interface EditAgeProps {
   register: UseFormRegister<UserEditData>;
 }
-const EditAge = ({ register }: EditAgeProps) => {
+const EditSex = ({ register }: EditAgeProps) => {
   const options = [
     { text: "남성", value: "male" },
     { text: "여성", value: "female" },
   ];
 
   return (
-    <S.EditAgeContainer>
+    <S.EditSexContainer>
       <GS.UserEditTitle>성별</GS.UserEditTitle>
 
-      <S.EditAgeActions>
+      <S.EditSexActions>
         {options.map(({ text, value }) => (
           <InputRadio
             key={`${text}_${value}`}
             value={value}
             text={text}
+            isSelected={true}
             register={register("sex", { required: "성별의 입력은 필수" })}
           />
         ))}
-      </S.EditAgeActions>
-    </S.EditAgeContainer>
+      </S.EditSexActions>
+    </S.EditSexContainer>
   );
 };
 
-export default EditAge;
+export default EditSex;
 
 interface createInputRadioProps {
   register: UseFormRegisterReturn;

--- a/src/app/user/[id]/setting/edit/components/UserEditInput/UserEditInput.styles.ts
+++ b/src/app/user/[id]/setting/edit/components/UserEditInput/UserEditInput.styles.ts
@@ -1,6 +1,6 @@
 import styled from "styled-components";
 
-export const EditNicknameActions = styled.div`
+export const InputActions = styled.div`
   display: flex;
   gap: 1rem;
 `;

--- a/src/app/user/[id]/setting/edit/components/UserEditInput/UserEditInput.tsx
+++ b/src/app/user/[id]/setting/edit/components/UserEditInput/UserEditInput.tsx
@@ -1,0 +1,55 @@
+import * as S from "./UserEditInput.styles";
+import * as GS from "../../UserEdit.styles";
+
+import { UseFormRegisterReturn } from "react-hook-form";
+import { Input, InputLabel } from "@/components";
+import { FONT_WEIGHT } from "@/styles/theme";
+
+interface UserEditInputProps {
+  title: string;
+  inputType: "text" | "number" | "date";
+  placeholder: string;
+  errorsMessage?: string;
+
+  register: UseFormRegisterReturn;
+}
+
+const UserEditInput = ({
+  title,
+  inputType,
+  placeholder,
+  errorsMessage,
+
+  register,
+}: UserEditInputProps) => {
+  return (
+    <>
+      <GS.UserEditTitle>{title}</GS.UserEditTitle>
+
+      <S.InputActions>
+        <Input
+          type={inputType}
+          register={register}
+          placeholder={placeholder}
+          style={{
+            lineHeight: "2rem",
+            width: "100%",
+            fontSize: "1.5rem",
+            fontWeight: FONT_WEIGHT.SEMIBOLD,
+          }}
+        />
+      </S.InputActions>
+
+      <GS.UserEditWarning>
+        {errorsMessage && (
+          <InputLabel
+            text={errorsMessage}
+            type="danger"
+          />
+        )}
+      </GS.UserEditWarning>
+    </>
+  );
+};
+
+export default UserEditInput;

--- a/src/app/user/[id]/setting/edit/components/UserEditInput/UserEditInput.tsx
+++ b/src/app/user/[id]/setting/edit/components/UserEditInput/UserEditInput.tsx
@@ -3,7 +3,7 @@ import * as GS from "../../UserEdit.styles";
 
 import { UseFormRegisterReturn } from "react-hook-form";
 import { Input, InputLabel } from "@/components";
-import { FONT_WEIGHT } from "@/styles/theme";
+import { FONT_SIZE, FONT_WEIGHT } from "@/styles/theme";
 
 interface UserEditInputProps {
   title: string;
@@ -34,7 +34,7 @@ const UserEditInput = ({
           style={{
             lineHeight: "2rem",
             width: "100%",
-            fontSize: "1.5rem",
+            fontSize: FONT_SIZE.MEDIUM,
             fontWeight: FONT_WEIGHT.SEMIBOLD,
           }}
         />

--- a/src/app/user/[id]/setting/edit/components/index.ts
+++ b/src/app/user/[id]/setting/edit/components/index.ts
@@ -1,2 +1,7 @@
 export { default as EditNickname } from "./EditNickname/EditNickname";
 export { default as EditSex } from "./EditSex/EditSex";
+export { default as EditBirthDay } from "./EditBirthDay/EditBirthDay";
+export { default as EditBodyInfo } from "./EditBodyInfo/EditBodyInfo";
+export { default as EditIntensity } from "./EditIntensity/EditIntensity";
+
+export { default as UserEditInput } from "./UserEditInput/UserEditInput";

--- a/src/app/user/[id]/setting/edit/components/index.ts
+++ b/src/app/user/[id]/setting/edit/components/index.ts
@@ -1,1 +1,2 @@
 export { default as EditNickname } from "./EditNickname/EditNickname";
+export { default as EditAge } from "./EditAge/EditAge";

--- a/src/app/user/[id]/setting/edit/components/index.ts
+++ b/src/app/user/[id]/setting/edit/components/index.ts
@@ -1,2 +1,2 @@
 export { default as EditNickname } from "./EditNickname/EditNickname";
-export { default as EditAge } from "./EditAge/EditAge";
+export { default as EditSex } from "./EditSex/EditSex";

--- a/src/app/user/[id]/setting/edit/components/index.ts
+++ b/src/app/user/[id]/setting/edit/components/index.ts
@@ -1,0 +1,1 @@
+export { default as EditNickname } from "./EditNickname/EditNickname";

--- a/src/app/user/[id]/setting/edit/components/index.ts
+++ b/src/app/user/[id]/setting/edit/components/index.ts
@@ -1,6 +1,6 @@
 export { default as EditNickname } from "./EditNickname/EditNickname";
 export { default as EditSex } from "./EditSex/EditSex";
-export { default as EditBirthDay } from "./EditBirthDay/EditBirthDay";
+export { default as EditBirthDate } from "./EditBirthDate/EditBirthDate";
 export { default as EditBodyInfo } from "./EditBodyInfo/EditBodyInfo";
 export { default as EditIntensity } from "./EditIntensity/EditIntensity";
 

--- a/src/app/user/[id]/setting/edit/page.tsx
+++ b/src/app/user/[id]/setting/edit/page.tsx
@@ -8,9 +8,10 @@ interface UserEditParams {
 const FORM_DEFAULT_VALUE: UserEditData = {
   nickname: "임시값닉네임",
   sex: "female",
-  age: 12,
+  birthDay: "1994-12-26",
   height: 182,
   weight: 150,
+  intensity: "",
 };
 
 const UserEdit = ({ params }: { params: UserEditParams }) => {

--- a/src/app/user/[id]/setting/edit/page.tsx
+++ b/src/app/user/[id]/setting/edit/page.tsx
@@ -8,7 +8,7 @@ interface UserEditParams {
 const FORM_DEFAULT_VALUE: UserEditData = {
   nickname: "임시값닉네임",
   sex: "female",
-  birthDay: "1994-12-26",
+  birthDate: "1994-12-26",
   height: 182,
   weight: 150,
   intensity: "",

--- a/src/app/user/[id]/setting/edit/page.tsx
+++ b/src/app/user/[id]/setting/edit/page.tsx
@@ -1,13 +1,22 @@
 import UserEditController from "./UserEdit.controller";
+import { UserEditData } from "./UserEdit.types";
 
 interface UserEditParams {
   id: string;
 }
 
+const FORM_DEFAULT_VALUE: UserEditData = {
+  nickname: "임시값닉네임",
+  sex: "male",
+  age: 12,
+  height: 182,
+  weight: 150,
+};
+
 const UserEdit = ({ params }: { params: UserEditParams }) => {
   const { id } = params;
 
-  return <UserEditController userId={id} />;
+  return <UserEditController userData={FORM_DEFAULT_VALUE} />;
 };
 
 export default UserEdit;

--- a/src/app/user/[id]/setting/edit/page.tsx
+++ b/src/app/user/[id]/setting/edit/page.tsx
@@ -7,7 +7,7 @@ interface UserEditParams {
 
 const FORM_DEFAULT_VALUE: UserEditData = {
   nickname: "임시값닉네임",
-  sex: "male",
+  sex: "female",
   age: 12,
   height: 182,
   weight: 150,

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -18,7 +18,7 @@ interface ButtonProps {
   disabled?: boolean;
   useRipple?: boolean;
   rippleColor?: string;
-  onClickHandler?: () => void;
+  onClickHandler?: (event: MouseEvent<HTMLButtonElement>) => void;
   handlerDelay?: number;
   [key: string]: any;
 }
@@ -60,9 +60,16 @@ const Button: React.FC<ButtonProps> = forwardRef(
 
     const handleClick = useCallback(
       (event: MouseEvent<HTMLButtonElement>) => {
-        rippleRef.current && rippleRef.current.createRipple(event);
+        const { current } = rippleRef;
+        current && current.createRipple(event);
+
+        if (handlerDelay === 0) {
+          onClickHandler(event);
+          return;
+        }
+
         setTimeout(() => {
-          onClickHandler();
+          onClickHandler(event);
         }, handlerDelay);
       },
       [onClickHandler, handlerDelay],

--- a/src/components/InputRadio/InputRadio.styles.ts
+++ b/src/components/InputRadio/InputRadio.styles.ts
@@ -1,0 +1,24 @@
+import { FONT_SIZE, FONT_WEIGHT } from "@/styles/theme";
+import { styled } from "twin.macro";
+
+export const InputRadioLabel = styled.label<{ $isSelected: boolean }>`
+  padding: 1.5rem;
+  width: 100%;
+
+  display: flex;
+  align-items: center;
+  justify-content: center;
+
+  border-radius: 0.8rem;
+  background-color: ${({ theme, $isSelected }) =>
+    $isSelected ? theme.green_500 : theme.transparent_10};
+
+  font-size: ${FONT_SIZE.H5};
+  font-weight: ${FONT_WEIGHT.BOLD};
+  letter-spacing: 1px;
+  white-space: nowrap;
+  color: ${({ theme, $isSelected }) => ($isSelected ? theme.text_secondary_color : theme.gray_300)};
+
+  user-select: none;
+  cursor: pointer;
+`;

--- a/src/components/InputRadio/InputRadio.tsx
+++ b/src/components/InputRadio/InputRadio.tsx
@@ -1,0 +1,37 @@
+import { CSSProperties } from "react";
+import * as S from "./InputRadio.styles";
+
+import { UseFormRegisterReturn } from "react-hook-form";
+
+interface createInputRadioProps {
+  key?: string | number;
+  register: UseFormRegisterReturn;
+  value: string | number;
+  text: string;
+  isSelected: boolean;
+  style?: CSSProperties;
+}
+
+const InputRadio = ({ value, text, register, isSelected, style }: createInputRadioProps) => {
+  return (
+    <>
+      <input
+        type="radio"
+        id={`${text}_${value}`}
+        value={value}
+        style={{ display: "none" }}
+        {...register}
+      />
+
+      <S.InputRadioLabel
+        htmlFor={`${text}_${value}`}
+        $isSelected={isSelected}
+        style={{ ...style }}
+      >
+        {text}
+      </S.InputRadioLabel>
+    </>
+  );
+};
+
+export default InputRadio;

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -11,3 +11,4 @@ export { default as ListCard } from "./ListCard";
 export { default as PinDetailCard } from "./PinDetailCard";
 export { default as Window } from "./Window";
 export { default as Textarea } from "./Textarea";
+export { default as InputRadio } from "./InputRadio/InputRadio";

--- a/src/constants/userValidate.ts
+++ b/src/constants/userValidate.ts
@@ -1,6 +1,56 @@
-export const USER_VALIDATE = {
+const USER_VALIDATE_NUMBER = {
   NICKNAME: {
     MIN_LENGTH: 2,
     MAX_LENGTH: 10,
+  },
+};
+
+export const validation_user = {
+  nickname: {
+    required: "변경하실 닉네임을 입력해주세요.",
+    minLength: {
+      value: USER_VALIDATE_NUMBER.NICKNAME.MIN_LENGTH,
+      message: `${USER_VALIDATE_NUMBER.NICKNAME.MIN_LENGTH}글자 이상을 입력해 주세요.`,
+    },
+    maxLength: {
+      value: USER_VALIDATE_NUMBER.NICKNAME.MAX_LENGTH,
+      message: `${USER_VALIDATE_NUMBER.NICKNAME.MAX_LENGTH}글자 이하로 입력해 주세요.`,
+    },
+  },
+
+  height: {
+    required: "키는 필수 항목입니다.",
+    min: {
+      value: 80,
+      message: "값이 너무 작습니다.",
+    },
+    max: {
+      value: 220,
+      message: "값이 너무 큽니다.",
+    },
+  },
+
+  weight: {
+    required: "체중은 필수 항목입니다.",
+    min: {
+      value: 30,
+      message: "값이 너무 작습니다.",
+    },
+    max: {
+      value: 280,
+      message: "값이 너무 큽니다.",
+    },
+  },
+
+  birthDay: {
+    required: "나이는 필수 항목입니다.",
+    min: {
+      value: 14,
+      message: "14세 이상이어야 합니다",
+    },
+    max: {
+      value: 100,
+      message: "100세 이하여야 합니다",
+    },
   },
 };

--- a/src/constants/userValidate.ts
+++ b/src/constants/userValidate.ts
@@ -1,0 +1,6 @@
+export const USER_VALIDATE = {
+  NICKNAME: {
+    MIN_LENGTH: 2,
+    MAX_LENGTH: 10,
+  },
+};

--- a/src/constants/userValidate.ts
+++ b/src/constants/userValidate.ts
@@ -42,7 +42,7 @@ export const validation_user = {
     },
   },
 
-  birthDay: {
+  birthDate: {
     required: "나이는 필수 항목입니다.",
     min: {
       value: 14,

--- a/src/constants/variable.ts
+++ b/src/constants/variable.ts
@@ -1,0 +1,7 @@
+export const INTENSITY_OPTIONS = [
+  { label: "좌식", value: "SUPER_LOW" },
+  { label: "가벼운 활동(가벼운 운동/스포츠 3-5일/주)", value: "LOW" },
+  { label: "적당히 활동적(중간 정도의 운동/스포츠 3-5일/주)", value: "MIDDLE" },
+  { label: "활동적(일주일에 6-7일 격렬한 운동/스포츠)", value: "HIGH" },
+  { label: "매우 활독적인 경우 (매우 힘든 운동/스포츠 및 육체 노동)", value: "SUPER_HIGH" },
+];

--- a/src/constants/variable.ts
+++ b/src/constants/variable.ts
@@ -1,7 +1,14 @@
+import { SexOption } from "@/types/OriginDataType/";
+
 export const INTENSITY_OPTIONS = [
   { label: "좌식", value: "SUPER_LOW" },
   { label: "가벼운 활동(가벼운 운동/스포츠 3-5일/주)", value: "LOW" },
   { label: "적당히 활동적(중간 정도의 운동/스포츠 3-5일/주)", value: "MIDDLE" },
   { label: "활동적(일주일에 6-7일 격렬한 운동/스포츠)", value: "HIGH" },
   { label: "매우 활독적인 경우 (매우 힘든 운동/스포츠 및 육체 노동)", value: "SUPER_HIGH" },
+];
+
+export const SEX_OPTIONS: SexOption[] = [
+  { label: "남성", value: "male" },
+  { label: "여성", value: "female" },
 ];

--- a/src/styles/theme.ts
+++ b/src/styles/theme.ts
@@ -1,3 +1,5 @@
+import { css } from "styled-components";
+
 export const lightTheme = {
   theme_mode: "light",
 
@@ -145,3 +147,12 @@ export const FONT_SIZE = {
   MINI: "1.2rem",
   MICRO: "1rem",
 };
+
+export const DISPLAY_NONE_SCROLLBAR = css`
+  -ms-overflow-style: none;
+  scrollbar-width: none;
+
+  &::-webkit-scrollbar {
+    display: none;
+  }
+`;

--- a/src/types/OriginDataType/IntensityOption.ts
+++ b/src/types/OriginDataType/IntensityOption.ts
@@ -1,0 +1,1 @@
+export type IntensityOption = "SUPER_LOW" | "LOW" | "MIDDLE" | "HIGH" | "SUPER_HIGH" | "";

--- a/src/types/OriginDataType/SexOption.ts
+++ b/src/types/OriginDataType/SexOption.ts
@@ -1,0 +1,4 @@
+export interface SexOption {
+  label: string;
+  value: "male" | "female";
+}

--- a/src/types/OriginDataType/index.ts
+++ b/src/types/OriginDataType/index.ts
@@ -1,2 +1,4 @@
 export * from "./Pin";
 export * from "./GeoPosition";
+export * from "./IntensityOption";
+export * from "./SexOption";


### PR DESCRIPTION
## 🔗 이슈 링크

- #123 

close #123 


https://github.com/Team-SilverTown/Team-SilverTown-MasilGasil-FE/assets/127748428/22d41d2c-b14b-4361-b05a-4537af642c47

## 💡 핵심 구현 사항
- `page.tsx` 에서 `SSR`을 통해 userData를 처음에 불러오도록 계획을 변경하였습니다
  - 추후 불러온 데이터로 기본 `default` 상태를 지정할 예정입니다.

- `Nickname` 컴포넌트를 구현했습니다.
  - 닉네임 input에 변경 동작을 할 시 중복 확인을 필수적으로 하도록 구현하였습니다.
  - 이후 기존 닉네임을 입력시 중복체크가 필요없도록 구현하였습니다.

- 성별
  - `InputRadio` 컴포넌트를 구현하였습니다. 
  - 생김새는 버튼과 동일하지만, 기능은 `Radio` 기능이라도 생각되어 별도로 제작하였습니다.
  - 최종 리팩토링 과정에서 다른 컴포넌트에서 사용되지않을 경우 해당 디렉토리 구조 내부로 옮기도록하겠습니다.

## ➕ 추가 작업 사항
<!-- 주 Task 이외의 작업한 변경 사항  -->
- 


## 🤔 테스트 및 검증 && 고민 사항
<!-- 배포에서 체크해봐야 할 부분 -->
<!-- 궁금한 점, 팀원들의 의견이 필요한 부분, 크로스체크가 필요한 부분 등 -->
- 


## 💬 피드백 반영사항
<!-- 피드백 요청 사항을 리스트로 표시하고 반영 여부를 표시합니다 -->
- 
