### PR TITLE
Refactoring/user edit/#131

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -24,8 +24,8 @@ export default async function RootLayout({
 }: Readonly<{
   children: React.ReactNode;
 }>) {
-  const data = await serverGetTest();
-  console.log("SERVER", data);
+  // const data = await serverGetTest();
+  // console.log("SERVER", data);
 
   return (
     <html lang="ko">

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -24,8 +24,8 @@ export default async function RootLayout({
 }: Readonly<{
   children: React.ReactNode;
 }>) {
-  // const data = await serverGetTest();
-  // console.log("SERVER", data);
+  const data = await serverGetTest();
+  console.log("SERVER", data);
 
   return (
     <html lang="ko">

--- a/src/app/mate/[id]/Mate.view.tsx
+++ b/src/app/mate/[id]/Mate.view.tsx
@@ -1,0 +1,3 @@
+const MateView = () => {
+  return <div>Mate.view</div>;
+};

--- a/src/app/mate/[id]/Mate.view.tsx
+++ b/src/app/mate/[id]/Mate.view.tsx
@@ -1,3 +1,0 @@
-const MateView = () => {
-  return <div>Mate.view</div>;
-};

--- a/src/app/signin/SignIn.constants.ts
+++ b/src/app/signin/SignIn.constants.ts
@@ -7,39 +7,3 @@ export const SEX_OPTIONS: SexOptionProps[] = [
   { label: "남성", value: "male" },
   { label: "여성", value: "female" },
 ];
-
-export const signInValidation = {
-  birthDate: {
-    required: "나이는 필수 항목입니다.",
-    min: {
-      value: 14,
-      message: "14세 이상이어야 합니다",
-    },
-    max: {
-      value: 100,
-      message: "100세 이하여야 합니다",
-    },
-  },
-  height: {
-    required: "키는 필수 항목입니다.",
-    min: {
-      value: 50,
-      message: "값이 너무 작습니다.",
-    },
-    max: {
-      value: 500,
-      message: "값이 너무 큽니다.",
-    },
-  },
-  weight: {
-    required: "체중은 필수 항목입니다.",
-    min: {
-      value: 10,
-      message: "값이 너무 작습니다.",
-    },
-    max: {
-      value: 500,
-      message: "값이 너무 큽니다.",
-    },
-  },
-};

--- a/src/app/signin/SignIn.constants.ts
+++ b/src/app/signin/SignIn.constants.ts
@@ -1,9 +1,0 @@
-export interface SexOptionProps {
-  label: string;
-  value: "male" | "female";
-}
-
-export const SEX_OPTIONS: SexOptionProps[] = [
-  { label: "남성", value: "male" },
-  { label: "여성", value: "female" },
-];

--- a/src/app/signin/SignIn.controller.tsx
+++ b/src/app/signin/SignIn.controller.tsx
@@ -9,6 +9,7 @@ import { SignInStep1, SignInStep2, SignInStep3, SignInStep4 } from "./sections";
 import { TopNavigator } from "@/components/navigators/TopNavigator";
 import { GoBackButton, StepSkipButton } from "@/components/navigators/TopNavigator/components";
 import { useRouter } from "next/navigation";
+import { IntensityOption } from "@/types/OriginDataType";
 
 export interface SignInFormProps {
   nickname: string;
@@ -16,7 +17,7 @@ export interface SignInFormProps {
   birthDate?: number;
   height?: number;
   weight?: number;
-  exerciseIntensity?: "SUPER_LOW" | "LOW" | "MIDDLE" | "HIGH" | "SUPER_HIGH";
+  exerciseIntensity?: IntensityOption;
   policy_personal: boolean;
   policy_location: boolean;
   policy_age: boolean;

--- a/src/app/signin/sections/SignInStep1.tsx
+++ b/src/app/signin/sections/SignInStep1.tsx
@@ -5,6 +5,7 @@ import useTheme from "@/lib/hooks/useTheme";
 
 import { Button, Input, InputLabel } from "@/components";
 import { SignInFormProps } from "../SignIn.controller";
+import { validation_user } from "@/constants/userValidate";
 
 interface SignInStep1Props {
   register: UseFormRegister<SignInFormProps>;
@@ -20,13 +21,7 @@ const SignInStep1 = ({ register, errors }: SignInStep1Props) => {
         <div className="relative flex-1 space-y-2">
           <Input
             required
-            register={register("nickname", {
-              required: "NickName is required",
-              minLength: {
-                message: "NickName Should be longer then 2 chars",
-                value: 2,
-              },
-            })}
+            register={register("nickname", validation_user.nickname)}
             placeholder="닉네임을 입력해주세요."
             style={{
               fontSize: "1.5rem",

--- a/src/app/signin/sections/SignInStep2.tsx
+++ b/src/app/signin/sections/SignInStep2.tsx
@@ -8,8 +8,9 @@ import useTheme from "@/lib/hooks/useTheme";
 import { Button, Input, InputLabel } from "@/components";
 import { SignInFormProps } from "../SignIn.controller";
 import useSignInModel from "../SignIn.model";
-import { SEX_OPTIONS, signInValidation } from "../SignIn.constants";
+import { SEX_OPTIONS } from "../SignIn.constants";
 import * as S from "../SignIn.styles";
+import { validation_user } from "@/constants/userValidate";
 
 interface SignInStep2Props {
   setValue: UseFormSetValue<SignInFormProps>;
@@ -69,20 +70,20 @@ const SignInStep2 = ({ setValue, register, errors }: SignInStep2Props) => {
   const birthDateInput = createInput({
     register,
     name: "birthDate",
-    validation: signInValidation.birthDate,
+    validation: validation_user.age,
     placeholder: "만 나이를 입력해주세요.",
   });
   const heightInput = createInput({
     register,
     name: "height",
-    validation: signInValidation.height,
+    validation: validation_user.height,
     placeholder: "키를 입력해주세요.",
     unit: "cm",
   });
   const weightInput = createInput({
     register,
     name: "weight",
-    validation: signInValidation.weight,
+    validation: validation_user.weight,
     placeholder: "체중을 입력해주세요.",
     unit: "kg",
   });

--- a/src/app/signin/sections/SignInStep2.tsx
+++ b/src/app/signin/sections/SignInStep2.tsx
@@ -70,7 +70,7 @@ const SignInStep2 = ({ setValue, register, errors }: SignInStep2Props) => {
   const birthDateInput = createInput({
     register,
     name: "birthDate",
-    validation: validation_user.age,
+    validation: validation_user.birthDay,
     placeholder: "만 나이를 입력해주세요.",
   });
   const heightInput = createInput({

--- a/src/app/signin/sections/SignInStep2.tsx
+++ b/src/app/signin/sections/SignInStep2.tsx
@@ -8,9 +8,10 @@ import useTheme from "@/lib/hooks/useTheme";
 import { Button, Input, InputLabel } from "@/components";
 import { SignInFormProps } from "../SignIn.controller";
 import useSignInModel from "../SignIn.model";
-import { SEX_OPTIONS } from "../SignIn.constants";
+// import { SEX_OPTIONS } from "../SignIn.constants";
 import * as S from "../SignIn.styles";
 import { validation_user } from "@/constants/userValidate";
+import { SEX_OPTIONS } from "@/constants/variable";
 
 interface SignInStep2Props {
   setValue: UseFormSetValue<SignInFormProps>;

--- a/src/app/user/[id]/setting/components/UserSettingMember/UserSettingMember.controller.tsx
+++ b/src/app/user/[id]/setting/components/UserSettingMember/UserSettingMember.controller.tsx
@@ -1,7 +1,15 @@
+import { usePathname, useRouter } from "next/navigation";
 import UserSettingMemberView from "./UserSettingMember.view";
 
 const UserSettingMemberController = () => {
-  return <UserSettingMemberView />;
+  const router = useRouter();
+  const pathName = usePathname();
+
+  const handleClick = () => {
+    router.push(`${pathName}/edit`);
+  };
+
+  return <UserSettingMemberView onClick={handleClick} />;
 };
 
 export default UserSettingMemberController;

--- a/src/app/user/[id]/setting/components/UserSettingMember/UserSettingMember.view.tsx
+++ b/src/app/user/[id]/setting/components/UserSettingMember/UserSettingMember.view.tsx
@@ -11,7 +11,6 @@ const UserSettingMemberView = ({ onClick }: UserSettingMemberViewProps) => {
     <GS.UserSettingInnerLayout>
       <GS.UserSettingTitle>회원</GS.UserSettingTitle>
 
-      {/* Route를 통한 페이지 이동 */}
       <SettingContent
         icon={<AccountManager />}
         text={"회원 수정"}

--- a/src/app/user/[id]/setting/components/UserSettingMember/UserSettingMember.view.tsx
+++ b/src/app/user/[id]/setting/components/UserSettingMember/UserSettingMember.view.tsx
@@ -2,7 +2,11 @@ import { AccountManager } from "@/components/icons";
 import * as GS from "../../UserSetting.styles";
 import { SettingContent } from "..";
 
-const UserSettingMemberView = () => {
+interface UserSettingMemberViewProps {
+  onClick: () => void;
+}
+
+const UserSettingMemberView = ({ onClick }: UserSettingMemberViewProps) => {
   return (
     <GS.UserSettingInnerLayout>
       <GS.UserSettingTitle>회원</GS.UserSettingTitle>
@@ -11,7 +15,7 @@ const UserSettingMemberView = () => {
       <SettingContent
         icon={<AccountManager />}
         text={"회원 수정"}
-        onClick={() => {}}
+        onClick={onClick}
       />
     </GS.UserSettingInnerLayout>
   );

--- a/src/app/user/[id]/setting/edit/UserEdit.constants.ts
+++ b/src/app/user/[id]/setting/edit/UserEdit.constants.ts
@@ -1,22 +1,3 @@
-import { USER_VALIDATE } from "@/constants/userValidate";
-
-export const USER_EDIT_ERROR_MESSAGE = {
-  NICKNAME: {
-    REQUIRE: "변경하실 닉네임을 입력해주세요.",
-    MIN_LENGTH: `${USER_VALIDATE.NICKNAME.MIN_LENGTH}글자 이상을 입력해 주세요.`,
-    MAX_LENGTH: `${USER_VALIDATE.NICKNAME.MAX_LENGTH}글자 이하로 입력해 주세요.`,
-  },
-  AGE: {
-    REQUIRE: "변경하실 나이를 입력해주세요.",
-  },
-  HEIGHT: {
-    REQUIRE: "변경하실 키를 입력해주세요.",
-  },
-  WEIGHT: {
-    REQUIRE: "변경하실 몸무게를 입력해주세요.",
-  },
-};
-
 export const USER_EDIT_PLACEHOLDER = {
   NICKNAME: "수정하실 닉네임을 입력해주세요.",
   AGE: "수정하실 나이를 입력해주세요.",

--- a/src/app/user/[id]/setting/edit/UserEdit.constants.ts
+++ b/src/app/user/[id]/setting/edit/UserEdit.constants.ts
@@ -1,6 +1,6 @@
 export const USER_EDIT_PLACEHOLDER = {
   NICKNAME: "수정하실 닉네임을 입력해주세요.",
-  AGE: "수정하실 나이를 입력해주세요.",
+  BIRTHDAY: "수정하실 나이를 입력해주세요.",
   HEIGHT: "수정하실 키를 입력해주세요.",
   WEIGHT: "수정하실 몸무게를 입력해주세요.",
 };

--- a/src/app/user/[id]/setting/edit/UserEdit.styles.ts
+++ b/src/app/user/[id]/setting/edit/UserEdit.styles.ts
@@ -1,7 +1,8 @@
 import { DISPLAY_NONE_SCROLLBAR, FONT_SIZE, FONT_WEIGHT } from "@/styles/theme";
+import { motion } from "framer-motion";
 import styled from "styled-components";
 
-export const UserEditLayout = styled.form`
+export const UserEditLayout = styled(motion.form)`
   width: 100%;
   height: 100%;
 

--- a/src/app/user/[id]/setting/edit/UserEdit.styles.ts
+++ b/src/app/user/[id]/setting/edit/UserEdit.styles.ts
@@ -31,7 +31,7 @@ export const UserEditTitle = styled.h6`
 
 export const UserEditWarning = styled.div`
   width: 100%;
-  height: 2.4rem;
+  min-height: 2.4rem;
   padding-left: 0.6rem;
 
   display: flex;

--- a/src/app/user/[id]/setting/edit/UserEdit.styles.ts
+++ b/src/app/user/[id]/setting/edit/UserEdit.styles.ts
@@ -5,6 +5,7 @@ import styled from "styled-components";
 export const UserEditLayout = styled(motion.form)`
   width: 100%;
   height: 100%;
+  padding: 2rem 0;
 
   display: flex;
   flex-direction: column;

--- a/src/app/user/[id]/setting/edit/UserEdit.styles.ts
+++ b/src/app/user/[id]/setting/edit/UserEdit.styles.ts
@@ -31,15 +31,9 @@ export const UserEditTitle = styled.h6`
 
 export const UserEditWarning = styled.div`
   width: 100%;
-  min-height: 2.4rem;
+  min-height: 2.8rem;
   padding-left: 0.6rem;
 
   display: flex;
   align-items: center;
-
-  white-space: nowrap;
-
-  overflow: scroll;
-
-  ${DISPLAY_NONE_SCROLLBAR}
 `;

--- a/src/app/user/[id]/setting/edit/UserEdit.types.ts
+++ b/src/app/user/[id]/setting/edit/UserEdit.types.ts
@@ -3,7 +3,7 @@ export type IntensityType = "SUPER_LOW" | "LOW" | "MIDDLE" | "HIGH" | "SUPER_HIG
 export interface UserEditData {
   nickname: string;
   sex: "male" | "female";
-  age: number;
+  age: string;
   height: number;
   weight: number;
   intensity: IntensityType;

--- a/src/app/user/[id]/setting/edit/UserEdit.types.ts
+++ b/src/app/user/[id]/setting/edit/UserEdit.types.ts
@@ -3,7 +3,7 @@ export type IntensityType = "SUPER_LOW" | "LOW" | "MIDDLE" | "HIGH" | "SUPER_HIG
 export interface UserEditData {
   nickname: string;
   sex: "male" | "female";
-  age: string;
+  birthDay: string;
   height: number;
   weight: number;
   intensity: IntensityType;

--- a/src/app/user/[id]/setting/edit/UserEdit.types.ts
+++ b/src/app/user/[id]/setting/edit/UserEdit.types.ts
@@ -1,4 +1,4 @@
-export type IntensityType = "SUPER_LOW" | "LOW" | "MIDDLE" | "HIGH" | "SUPER_HIGH" | "";
+import { IntensityOption } from "@/types/OriginDataType";
 
 export interface UserEditData {
   nickname: string;
@@ -6,5 +6,5 @@ export interface UserEditData {
   birthDay: string;
   height: number;
   weight: number;
-  intensity: IntensityType;
+  intensity: IntensityOption;
 }

--- a/src/app/user/[id]/setting/edit/UserEdit.view.tsx
+++ b/src/app/user/[id]/setting/edit/UserEdit.view.tsx
@@ -4,7 +4,7 @@ import * as S from "./UserEdit.styles";
 import { FieldErrors, UseFormHandleSubmit, UseFormRegister } from "react-hook-form";
 import { IntensityType, UserEditData } from "./UserEdit.types";
 
-import { EditSex, EditNickname, EditAge, EditBodyInfo, EditIntensity } from "./components";
+import { EditSex, EditNickname, EditBirthDay, EditBodyInfo, EditIntensity } from "./components";
 
 interface UserEditViewProps {
   register: UseFormRegister<UserEditData>;
@@ -51,7 +51,7 @@ const UserEditView = ({
           selectedSex={selectedSex}
         />
 
-        <EditAge
+        <EditBirthDay
           register={register}
           errors={errors}
         />

--- a/src/app/user/[id]/setting/edit/UserEdit.view.tsx
+++ b/src/app/user/[id]/setting/edit/UserEdit.view.tsx
@@ -5,6 +5,9 @@ import { FieldErrors, UseFormHandleSubmit, UseFormRegister } from "react-hook-fo
 import { IntensityType, UserEditData } from "./UserEdit.types";
 
 import { EditSex, EditNickname, EditBirthDay, EditBodyInfo, EditIntensity } from "./components";
+import { Button } from "@/components";
+import useTheme from "@/lib/hooks/useTheme";
+import { FONT_SIZE, FONT_WEIGHT } from "@/styles/theme";
 
 interface UserEditViewProps {
   register: UseFormRegister<UserEditData>;
@@ -33,6 +36,12 @@ const UserEditView = ({
   isCheckedNickname,
   onCheckSameNickname,
 }: UserEditViewProps) => {
+  const theme = useTheme();
+
+  if (!theme) {
+    return;
+  }
+
   return (
     <GS.CommonContainer
       style={{ height: "100%" }}
@@ -69,7 +78,20 @@ const UserEditView = ({
           selectedIntensity={selectedIntensity}
         />
 
-        <button>테스트용 제출 버튼</button>
+        <Button
+          variant="flat"
+          useRipple
+          rippleColor={theme.text_secondary_color + 50}
+          buttonColor={theme.green_500}
+          textColor={theme.text_secondary_color}
+          style={{
+            fontSize: FONT_SIZE.H4,
+            fontWeight: FONT_WEIGHT.BOLD,
+            minHeight: "5rem",
+          }}
+        >
+          수정 완료
+        </Button>
       </S.UserEditLayout>
     </GS.CommonContainer>
   );

--- a/src/app/user/[id]/setting/edit/UserEdit.view.tsx
+++ b/src/app/user/[id]/setting/edit/UserEdit.view.tsx
@@ -38,7 +38,10 @@ const UserEditView = ({
       style={{ height: "100%" }}
       onSubmit={onSubmit(onValid, onInValid)}
     >
-      <S.UserEditLayout>
+      <S.UserEditLayout
+        initial={{ x: "-120%" }}
+        animate={{ x: 0 }}
+      >
         <EditNickname
           register={register}
           errors={errors}

--- a/src/app/user/[id]/setting/edit/UserEdit.view.tsx
+++ b/src/app/user/[id]/setting/edit/UserEdit.view.tsx
@@ -38,10 +38,6 @@ const UserEditView = ({
 }: UserEditViewProps) => {
   const theme = useTheme();
 
-  if (!theme) {
-    return;
-  }
-
   return (
     <GS.CommonContainer
       style={{ height: "100%" }}
@@ -81,9 +77,9 @@ const UserEditView = ({
         <Button
           variant="flat"
           useRipple
-          rippleColor={theme.text_secondary_color + 50}
-          buttonColor={theme.green_500}
-          textColor={theme.text_secondary_color}
+          rippleColor={theme?.text_secondary_color + 50}
+          buttonColor={theme?.green_500}
+          textColor={theme?.text_secondary_color}
           style={{
             fontSize: FONT_SIZE.H4,
             fontWeight: FONT_WEIGHT.BOLD,

--- a/src/app/user/[id]/setting/edit/UserEdit.view.tsx
+++ b/src/app/user/[id]/setting/edit/UserEdit.view.tsx
@@ -2,12 +2,13 @@ import * as GS from "@/styles/GlobalStyle";
 import * as S from "./UserEdit.styles";
 
 import { FieldErrors, UseFormHandleSubmit, UseFormRegister } from "react-hook-form";
-import { IntensityType, UserEditData } from "./UserEdit.types";
+import { UserEditData } from "./UserEdit.types";
 
 import { EditSex, EditNickname, EditBirthDay, EditBodyInfo, EditIntensity } from "./components";
 import { Button } from "@/components";
 import useTheme from "@/lib/hooks/useTheme";
 import { FONT_SIZE, FONT_WEIGHT } from "@/styles/theme";
+import { IntensityOption } from "@/types/OriginDataType";
 
 interface UserEditViewProps {
   register: UseFormRegister<UserEditData>;
@@ -18,7 +19,7 @@ interface UserEditViewProps {
   onInValid: (error: FieldErrors) => void;
 
   selectedSex: string;
-  selectedIntensity: IntensityType;
+  selectedIntensity: IntensityOption;
   isCheckedNickname: boolean;
   onCheckSameNickname: () => void;
 }

--- a/src/app/user/[id]/setting/edit/components/EditAge/EditAge.tsx
+++ b/src/app/user/[id]/setting/edit/components/EditAge/EditAge.tsx
@@ -2,8 +2,9 @@ import * as GS from "../../UserEdit.styles";
 
 import { FieldErrors, UseFormRegister } from "react-hook-form";
 import { UserEditData } from "../../UserEdit.types";
-import { USER_EDIT_ERROR_MESSAGE, USER_EDIT_PLACEHOLDER } from "../../UserEdit.constants";
+import { USER_EDIT_PLACEHOLDER } from "../../UserEdit.constants";
 import { UserEditInput } from "..";
+import { validation_user } from "@/constants/userValidate";
 
 interface EditAgeProps {
   register: UseFormRegister<UserEditData>;
@@ -17,9 +18,7 @@ const EditAge = ({ register, errors }: EditAgeProps) => {
         title={"나이"}
         inputType={"number"}
         placeholder={USER_EDIT_PLACEHOLDER.AGE}
-        register={register("age", {
-          required: USER_EDIT_ERROR_MESSAGE.AGE.REQUIRE,
-        })}
+        register={register("age", validation_user.age)}
         errorsMessage={errors.age && errors.age.message}
       />
     </GS.UserEditSectionContainer>

--- a/src/app/user/[id]/setting/edit/components/EditBirthDay/EditBirthDay.tsx
+++ b/src/app/user/[id]/setting/edit/components/EditBirthDay/EditBirthDay.tsx
@@ -17,9 +17,9 @@ const EditBirthDay = ({ register, errors }: EditAgeProps) => {
       <UserEditInput
         title={"나이"}
         inputType={"date"}
-        placeholder={USER_EDIT_PLACEHOLDER.AGE}
-        register={register("age", validation_user.age)}
-        errorsMessage={errors.age && errors.age.message}
+        placeholder={USER_EDIT_PLACEHOLDER.BIRTHDAY}
+        register={register("birthDay", validation_user.birthDay)}
+        errorsMessage={errors.birthDay && errors.birthDay.message}
       />
     </GS.UserEditSectionContainer>
   );

--- a/src/app/user/[id]/setting/edit/components/EditBirthDay/EditBirthDay.tsx
+++ b/src/app/user/[id]/setting/edit/components/EditBirthDay/EditBirthDay.tsx
@@ -11,12 +11,12 @@ interface EditAgeProps {
   errors: FieldErrors<UserEditData>;
 }
 
-const EditAge = ({ register, errors }: EditAgeProps) => {
+const EditBirthDay = ({ register, errors }: EditAgeProps) => {
   return (
     <GS.UserEditSectionContainer>
       <UserEditInput
         title={"나이"}
-        inputType={"number"}
+        inputType={"date"}
         placeholder={USER_EDIT_PLACEHOLDER.AGE}
         register={register("age", validation_user.age)}
         errorsMessage={errors.age && errors.age.message}
@@ -25,4 +25,4 @@ const EditAge = ({ register, errors }: EditAgeProps) => {
   );
 };
 
-export default EditAge;
+export default EditBirthDay;

--- a/src/app/user/[id]/setting/edit/components/EditBodyInfo/EditBodyInfo.tsx
+++ b/src/app/user/[id]/setting/edit/components/EditBodyInfo/EditBodyInfo.tsx
@@ -2,8 +2,9 @@ import * as S from "./EditBodyInfo.styles";
 
 import { FieldErrors, UseFormRegister } from "react-hook-form";
 import { UserEditData } from "../../UserEdit.types";
-import { USER_EDIT_ERROR_MESSAGE, USER_EDIT_PLACEHOLDER } from "../../UserEdit.constants";
+import { USER_EDIT_PLACEHOLDER } from "../../UserEdit.constants";
 import { UserEditInput } from "..";
+import { validation_user } from "@/constants/userValidate";
 
 interface EditBodyInfoProps {
   register: UseFormRegister<UserEditData>;
@@ -19,9 +20,7 @@ const EditBodyInfo = ({ register, errors }: EditBodyInfoProps) => {
           inputType={"number"}
           placeholder={USER_EDIT_PLACEHOLDER.HEIGHT}
           errorsMessage={errors.height && errors.height.message}
-          register={register("height", {
-            required: USER_EDIT_ERROR_MESSAGE.HEIGHT.REQUIRE,
-          })}
+          register={register("height", validation_user.height)}
         />
       </S.EditBodyInfoContainer>
 
@@ -31,9 +30,7 @@ const EditBodyInfo = ({ register, errors }: EditBodyInfoProps) => {
           inputType={"number"}
           placeholder={USER_EDIT_PLACEHOLDER.WEIGHT}
           errorsMessage={errors.weight && errors.weight.message}
-          register={register("weight", {
-            required: USER_EDIT_ERROR_MESSAGE.WEIGHT.REQUIRE,
-          })}
+          register={register("weight", validation_user.weight)}
         />
       </S.EditBodyInfoContainer>
     </S.EditBodyInfoLayout>

--- a/src/app/user/[id]/setting/edit/components/EditIntensity/EditIntensity.styles.ts
+++ b/src/app/user/[id]/setting/edit/components/EditIntensity/EditIntensity.styles.ts
@@ -23,6 +23,7 @@ export const IntensityDescription = styled.p`
 
 export const IntensityOptionList = styled.ul`
   width: 100%;
+  margin-bottom: 2.8rem;
 
   display: flex;
   flex-direction: column;

--- a/src/app/user/[id]/setting/edit/components/EditIntensity/EditIntensity.tsx
+++ b/src/app/user/[id]/setting/edit/components/EditIntensity/EditIntensity.tsx
@@ -3,12 +3,13 @@ import * as GS from "../../UserEdit.styles";
 import * as S from "./EditIntensity.styles";
 import useTheme from "@/lib/hooks/useTheme";
 import { UseFormRegister, UseFormRegisterReturn } from "react-hook-form";
-import { IntensityType, UserEditData } from "../../UserEdit.types";
+import { UserEditData } from "../../UserEdit.types";
 import { INTENSITY_OPTIONS } from "@/constants/variable";
+import { IntensityOption } from "@/types/OriginDataType";
 
 interface EditIntensityProps {
   register: UseFormRegister<UserEditData>;
-  selectedIntensity: IntensityType;
+  selectedIntensity: IntensityOption;
 }
 
 const EditIntensity = ({ register, selectedIntensity }: EditIntensityProps) => {

--- a/src/app/user/[id]/setting/edit/components/EditIntensity/EditIntensity.tsx
+++ b/src/app/user/[id]/setting/edit/components/EditIntensity/EditIntensity.tsx
@@ -47,10 +47,6 @@ interface IntensityItemProps {
 const IntensityItem = ({ isSelected, value, optionDescription, register }: IntensityItemProps) => {
   const theme = useTheme();
 
-  if (!theme) {
-    return;
-  }
-
   return (
     <S.IntensityItemContainer>
       <input
@@ -64,7 +60,7 @@ const IntensityItem = ({ isSelected, value, optionDescription, register }: Inten
         <S.IntensityItemCircle $isSelected={isSelected}>
           <Check
             className={`w-6 h-6 mx-auto my-auto transition-colors`}
-            stroke={isSelected ? theme.white_100 : theme.gray_300}
+            stroke={isSelected ? theme?.white_100 : theme?.gray_300}
             strokeWidth={3.5}
           />
         </S.IntensityItemCircle>

--- a/src/app/user/[id]/setting/edit/components/EditNickname/EditNickname.tsx
+++ b/src/app/user/[id]/setting/edit/components/EditNickname/EditNickname.tsx
@@ -27,10 +27,6 @@ const EditNickname = ({
 }: EditNicknameProps) => {
   const theme = useTheme();
 
-  if (!theme) {
-    return;
-  }
-
   const handleClick = (e: MouseEvent<HTMLButtonElement>) => {
     e.preventDefault();
     onCheckSameNickname();
@@ -55,10 +51,10 @@ const EditNickname = ({
 
         <Button
           width={"16rem"}
-          buttonColor={theme.green_500}
-          textColor={theme.text_secondary_color}
+          buttonColor={theme?.green_500}
+          textColor={theme?.text_secondary_color}
           useRipple
-          rippleColor={theme.text_secondary_color + 50}
+          rippleColor={theme?.text_secondary_color + 50}
           style={{
             whiteSpace: "nowrap",
             fontSize: FONT_SIZE.H5,

--- a/src/app/user/[id]/setting/edit/components/EditNickname/EditNickname.tsx
+++ b/src/app/user/[id]/setting/edit/components/EditNickname/EditNickname.tsx
@@ -6,8 +6,8 @@ import { UserEditData } from "../../UserEdit.types";
 import { Button, Input, InputLabel } from "@/components";
 import useTheme from "@/lib/hooks/useTheme";
 import { FONT_SIZE, FONT_WEIGHT } from "@/styles/theme";
-import { USER_EDIT_ERROR_MESSAGE, USER_EDIT_PLACEHOLDER } from "../../UserEdit.constants";
-import { USER_VALIDATE } from "@/constants/userValidate";
+import { USER_EDIT_PLACEHOLDER } from "../../UserEdit.constants";
+import { validation_user } from "@/constants/userValidate";
 import { MouseEvent } from "react";
 
 interface EditNicknameProps {
@@ -43,17 +43,7 @@ const EditNickname = ({
       <S.EditNicknameActions>
         <Input
           type="text"
-          register={register("nickname", {
-            required: USER_EDIT_ERROR_MESSAGE.NICKNAME.REQUIRE,
-            minLength: {
-              message: USER_EDIT_ERROR_MESSAGE.NICKNAME.MIN_LENGTH,
-              value: USER_VALIDATE.NICKNAME.MIN_LENGTH,
-            },
-            maxLength: {
-              message: USER_EDIT_ERROR_MESSAGE.NICKNAME.MAX_LENGTH,
-              value: USER_VALIDATE.NICKNAME.MAX_LENGTH,
-            },
-          })}
+          register={register("nickname", validation_user.nickname)}
           placeholder={USER_EDIT_PLACEHOLDER.NICKNAME}
           style={{
             lineHeight: "2rem",

--- a/src/app/user/[id]/setting/edit/components/EditSex/EditSex.tsx
+++ b/src/app/user/[id]/setting/edit/components/EditSex/EditSex.tsx
@@ -17,11 +17,11 @@ const EditSex = ({ register, selectedSex }: EditAgeProps) => {
       <GS.UserEditTitle>성별</GS.UserEditTitle>
 
       <S.EditSexActions>
-        {SEX_OPTIONS.map(({ text, value }) => (
+        {SEX_OPTIONS.map(({ label, value }) => (
           <InputRadio
-            key={`${text}_${value}`}
+            key={`${label}_${value}`}
             value={value}
-            text={text}
+            text={label}
             isSelected={selectedSex === value}
             register={register("sex")}
           />

--- a/src/app/user/[id]/setting/edit/components/EditSex/EditSex.tsx
+++ b/src/app/user/[id]/setting/edit/components/EditSex/EditSex.tsx
@@ -4,6 +4,7 @@ import * as S from "./EditSex.styles";
 import { UseFormRegister } from "react-hook-form";
 import { UserEditData } from "../../UserEdit.types";
 import { InputRadio } from "@/components";
+import { SEX_OPTIONS } from "@/constants/variable";
 
 interface EditAgeProps {
   register: UseFormRegister<UserEditData>;
@@ -11,17 +12,12 @@ interface EditAgeProps {
 }
 
 const EditSex = ({ register, selectedSex }: EditAgeProps) => {
-  const options = [
-    { text: "남성", value: "male" },
-    { text: "여성", value: "female" },
-  ];
-
   return (
     <GS.UserEditSectionContainer>
       <GS.UserEditTitle>성별</GS.UserEditTitle>
 
       <S.EditSexActions>
-        {options.map(({ text, value }) => (
+        {SEX_OPTIONS.map(({ text, value }) => (
           <InputRadio
             key={`${text}_${value}`}
             value={value}

--- a/src/app/user/[id]/setting/edit/components/UserEditInput/UserEditInput.tsx
+++ b/src/app/user/[id]/setting/edit/components/UserEditInput/UserEditInput.tsx
@@ -7,7 +7,7 @@ import { FONT_WEIGHT } from "@/styles/theme";
 
 interface UserEditInputProps {
   title: string;
-  inputType: "text" | "number";
+  inputType: "text" | "number" | "date";
   placeholder: string;
   errorsMessage?: string;
 

--- a/src/app/user/[id]/setting/edit/components/UserEditInput/UserEditInput.tsx
+++ b/src/app/user/[id]/setting/edit/components/UserEditInput/UserEditInput.tsx
@@ -3,7 +3,7 @@ import * as GS from "../../UserEdit.styles";
 
 import { UseFormRegisterReturn } from "react-hook-form";
 import { Input, InputLabel } from "@/components";
-import { FONT_WEIGHT } from "@/styles/theme";
+import { FONT_SIZE, FONT_WEIGHT } from "@/styles/theme";
 
 interface UserEditInputProps {
   title: string;
@@ -34,7 +34,7 @@ const UserEditInput = ({
           style={{
             lineHeight: "2rem",
             width: "100%",
-            fontSize: "1.5rem",
+            fontSize: FONT_SIZE.MEDIUM,
             fontWeight: FONT_WEIGHT.SEMIBOLD,
           }}
         />

--- a/src/app/user/[id]/setting/edit/components/index.ts
+++ b/src/app/user/[id]/setting/edit/components/index.ts
@@ -1,6 +1,6 @@
 export { default as EditNickname } from "./EditNickname/EditNickname";
 export { default as EditSex } from "./EditSex/EditSex";
-export { default as EditAge } from "./EditAge/EditAge";
+export { default as EditBirthDay } from "./EditBirthDay/EditBirthDay";
 export { default as EditBodyInfo } from "./EditBodyInfo/EditBodyInfo";
 export { default as EditIntensity } from "./EditIntensity/EditIntensity";
 

--- a/src/app/user/[id]/setting/edit/page.tsx
+++ b/src/app/user/[id]/setting/edit/page.tsx
@@ -8,7 +8,7 @@ interface UserEditParams {
 const FORM_DEFAULT_VALUE: UserEditData = {
   nickname: "임시값닉네임",
   sex: "female",
-  age: 12,
+  age: "1994-12-26",
   height: 182,
   weight: 150,
   intensity: "",

--- a/src/app/user/[id]/setting/edit/page.tsx
+++ b/src/app/user/[id]/setting/edit/page.tsx
@@ -8,7 +8,7 @@ interface UserEditParams {
 const FORM_DEFAULT_VALUE: UserEditData = {
   nickname: "임시값닉네임",
   sex: "female",
-  age: "1994-12-26",
+  birthDay: "1994-12-26",
   height: 182,
   weight: 150,
   intensity: "",

--- a/src/constants/userValidate.ts
+++ b/src/constants/userValidate.ts
@@ -1,6 +1,56 @@
-export const USER_VALIDATE = {
+const USER_VALIDATE_NUMBER = {
   NICKNAME: {
     MIN_LENGTH: 2,
     MAX_LENGTH: 10,
+  },
+};
+
+export const validation_user = {
+  nickname: {
+    required: "변경하실 닉네임을 입력해주세요.",
+    minLength: {
+      value: USER_VALIDATE_NUMBER.NICKNAME.MIN_LENGTH,
+      message: `${USER_VALIDATE_NUMBER.NICKNAME.MIN_LENGTH}글자 이상을 입력해 주세요.`,
+    },
+    maxLength: {
+      value: USER_VALIDATE_NUMBER.NICKNAME.MAX_LENGTH,
+      message: `${USER_VALIDATE_NUMBER.NICKNAME.MAX_LENGTH}글자 이하로 입력해 주세요.`,
+    },
+  },
+
+  height: {
+    required: "키는 필수 항목입니다.",
+    min: {
+      value: 80,
+      message: "값이 너무 작습니다.",
+    },
+    max: {
+      value: 220,
+      message: "값이 너무 큽니다.",
+    },
+  },
+
+  weight: {
+    required: "체중은 필수 항목입니다.",
+    min: {
+      value: 30,
+      message: "값이 너무 작습니다.",
+    },
+    max: {
+      value: 280,
+      message: "값이 너무 큽니다.",
+    },
+  },
+
+  age: {
+    required: "나이는 필수 항목입니다.",
+    min: {
+      value: 14,
+      message: "14세 이상이어야 합니다",
+    },
+    max: {
+      value: 100,
+      message: "100세 이하여야 합니다",
+    },
   },
 };

--- a/src/constants/userValidate.ts
+++ b/src/constants/userValidate.ts
@@ -42,7 +42,7 @@ export const validation_user = {
     },
   },
 
-  age: {
+  birthDay: {
     required: "나이는 필수 항목입니다.",
     min: {
       value: 14,

--- a/src/constants/variable.ts
+++ b/src/constants/variable.ts
@@ -1,3 +1,5 @@
+import { SexOption } from "@/types/OriginDataType/SexOption";
+
 export const INTENSITY_OPTIONS = [
   { label: "좌식", value: "SUPER_LOW" },
   { label: "가벼운 활동(가벼운 운동/스포츠 3-5일/주)", value: "LOW" },
@@ -6,12 +8,7 @@ export const INTENSITY_OPTIONS = [
   { label: "매우 활독적인 경우 (매우 힘든 운동/스포츠 및 육체 노동)", value: "SUPER_HIGH" },
 ];
 
-export interface SexOptionProps {
-  label: string;
-  value: "male" | "female";
-}
-
-export const SEX_OPTIONS: SexOptionProps[] = [
+export const SEX_OPTIONS: SexOption[] = [
   { label: "남성", value: "male" },
   { label: "여성", value: "female" },
 ];

--- a/src/constants/variable.ts
+++ b/src/constants/variable.ts
@@ -5,3 +5,8 @@ export const INTENSITY_OPTIONS = [
   { label: "활동적(일주일에 6-7일 격렬한 운동/스포츠)", value: "HIGH" },
   { label: "매우 활독적인 경우 (매우 힘든 운동/스포츠 및 육체 노동)", value: "SUPER_HIGH" },
 ];
+
+export const SEX_OPTIONS = [
+  { text: "남성", value: "male" },
+  { text: "여성", value: "female" },
+];

--- a/src/constants/variable.ts
+++ b/src/constants/variable.ts
@@ -1,4 +1,4 @@
-import { SexOption } from "@/types/OriginDataType/SexOption";
+import { SexOption } from "@/types/OriginDataType/";
 
 export const INTENSITY_OPTIONS = [
   { label: "좌식", value: "SUPER_LOW" },

--- a/src/constants/variable.ts
+++ b/src/constants/variable.ts
@@ -6,7 +6,12 @@ export const INTENSITY_OPTIONS = [
   { label: "매우 활독적인 경우 (매우 힘든 운동/스포츠 및 육체 노동)", value: "SUPER_HIGH" },
 ];
 
-export const SEX_OPTIONS = [
-  { text: "남성", value: "male" },
-  { text: "여성", value: "female" },
+export interface SexOptionProps {
+  label: string;
+  value: "male" | "female";
+}
+
+export const SEX_OPTIONS: SexOptionProps[] = [
+  { label: "남성", value: "male" },
+  { label: "여성", value: "female" },
 ];

--- a/src/types/OriginDataType/IntensityOption.ts
+++ b/src/types/OriginDataType/IntensityOption.ts
@@ -1,0 +1,1 @@
+export type IntensityOption = "SUPER_LOW" | "LOW" | "MIDDLE" | "HIGH" | "SUPER_HIGH" | "";

--- a/src/types/OriginDataType/SexOption.ts
+++ b/src/types/OriginDataType/SexOption.ts
@@ -1,0 +1,4 @@
+export interface SexOption {
+  label: string;
+  value: "male" | "female";
+}

--- a/src/types/OriginDataType/index.ts
+++ b/src/types/OriginDataType/index.ts
@@ -1,2 +1,4 @@
 export * from "./Pin";
 export * from "./GeoPosition";
+export * from "./IntensityOption";
+export * from "./SexOption";


### PR DESCRIPTION
## 🔗 이슈 링크

- #131  


https://github.com/Team-SilverTown/Team-SilverTown-MasilGasil-FE/assets/127748428/ebccc0d3-f2d1-42a1-93ee-73165f6d9bc6

- 현 PR은 이전 PR의 머지 실수로 인해 다시 merge 하기위한 PR입니다 
- #132 

## 💡 핵심 구현 사항
- `Age` 나이 수정 부분을 생년월일로 변경 하였습니다.

- 임시 `애니메이션`을 추가하였습니다. ( 필요없다고 판단될시 제거 예정입니다. )

- 회원가입 , 회원 정보 수정 페이지의 공통 변수, 유효성 검사 부분을 전역으로 분리하였습니다.
  - `validation` 을 분리하고 일관된 형식으로 수정하였습니다.
  - 이 부분은 담당자끼리 추후 `메세지` 및 `검사 범위`를 조율하면 좋을것 같습니다.

- 기존 유저 설정 페이지에서 회원 정보 수정 페이지를 연결하였습니다.


## ➕ 추가 작업 사항
<!-- 주 Task 이외의 작업한 변경 사항  -->
- 


## 🤔 테스트 및 검증 && 고민 사항
<!-- 배포에서 체크해봐야 할 부분 -->
<!-- 궁금한 점, 팀원들의 의견이 필요한 부분, 크로스체크가 필요한 부분 등 -->
- 


## 💬 피드백 반영사항
<!-- 피드백 요청 사항을 리스트로 표시하고 반영 여부를 표시합니다 -->
- 

