### PR TITLE
[Feat] 마이페이지 프로필 사진 변경 API 구현

### DIFF
--- a/src/app/home/Home.styles.ts
+++ b/src/app/home/Home.styles.ts
@@ -2,8 +2,8 @@ export const HomePageContainer = `
   w-full
   min-h-screen
 
-  pt-32
-  pb-56
+  pt-40
+  pb-72
 
   box-border
 `;

--- a/src/app/home/components/WalkStartButton/WalkStartButton.tsx
+++ b/src/app/home/components/WalkStartButton/WalkStartButton.tsx
@@ -15,16 +15,15 @@ const WalkStartButton = () => {
         style={{
           position: "fixed",
           left: "50%",
-          bottom: "7rem",
+          bottom: "10.5rem",
           transform: "translateX(-50%)",
           maxWidth: `${CONTAINER.MAX_WIDTH}rem`,
           height: "6rem",
           fontSize: `${FONT_SIZE.H6}`,
           fontWeight: `${FONT_WEIGHT.BOLD}`,
-          opacity: "0.9",
         }}
       >
-        산책 기록 하기
+        산책하기
       </Button>
     </Link>
   );

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -71,12 +71,12 @@ export default async function RootLayout({
                     <BottomNavigator />
                   </main>
                   <ModalUI />
+                  <Toaster />
                   <LoadingSpinner />
                   <WindowUI />
                 </TanstackQueryProvider>
               </AuthLoader>
             </AuthContext>
-            <Toaster />
           </body>
         </StyledComponentsRegistry>
       </ManagedUIContext>

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -14,6 +14,7 @@ import { GlobalStyle } from "@/styles/GlobalStyle";
 
 import "src/styles/globals.css";
 import { authOptions } from "./api/auth/[...nextauth]/options";
+import { Toaster } from "@/components/ShadcnUi/ui/toaster";
 
 export const metadata: Metadata = {
   title: "마실가실",
@@ -75,6 +76,7 @@ export default async function RootLayout({
                 </TanstackQueryProvider>
               </AuthLoader>
             </AuthContext>
+            <Toaster />
           </body>
         </StyledComponentsRegistry>
       </ManagedUIContext>

--- a/src/app/log/record/components/LogRecordEdit/LogRecordEdit.view.tsx
+++ b/src/app/log/record/components/LogRecordEdit/LogRecordEdit.view.tsx
@@ -100,7 +100,7 @@ const LogRecordEditView = () => {
         width={"90%"}
         onClickHandler={handleSubmit}
       >
-        산책 기록하기
+        산책 저장하기
       </Button>
     </>
   );

--- a/src/app/log/record/components/LogRecordRecording/LogRecordRecording.view.tsx
+++ b/src/app/log/record/components/LogRecordRecording/LogRecordRecording.view.tsx
@@ -54,7 +54,7 @@ const LogRecordRecordingView = () => {
           width={"100%"}
           onClickHandler={handleClickCompleteRecord}
         >
-          마실 기록 완료
+          산책 끝내기
         </Button>
       </S.LogRecordActionContainer>
     </S.LogRecordActionLayout>

--- a/src/app/log/record/components/LogRecordStandby/LogRecordStandby.view.tsx
+++ b/src/app/log/record/components/LogRecordStandby/LogRecordStandby.view.tsx
@@ -19,7 +19,7 @@ const LogRecordStandbyView = () => {
         width={"100%"}
         onClickHandler={handleStartRecord}
       >
-        마실 기록 시작
+        산책 시작하기
       </Button>
     </S.LogRecordStandbyLayout>
   );

--- a/src/app/user/[id]/components/MyRecordList/MyRecordList.styles.ts
+++ b/src/app/user/[id]/components/MyRecordList/MyRecordList.styles.ts
@@ -17,7 +17,8 @@ export const BorderTitleSection = styled.div`
     color: ${(props) => props.theme.black};
   }
 
-  a {
+  a,
+  span {
     font-size: 1.4rem;
     font-weight: ${FONT_WEIGHT.MEDIUM};
     color: ${(props) => props.theme.gray_500};

--- a/src/app/user/[id]/components/MyRecordList/MyRecordList.tsx
+++ b/src/app/user/[id]/components/MyRecordList/MyRecordList.tsx
@@ -7,6 +7,7 @@ import { LogDetailCard, LogSimpleCard } from "@/components";
 import { ProfileResponse, RecentMasil } from "@/types/Response";
 import * as S from "./MyRecordList.styles";
 import { PostListItem } from "@/types/OriginDataType/Post";
+import { toast } from "@/components/ShadcnUi/ui/useToast";
 
 interface MyRecordListProps {
   title: string;
@@ -24,12 +25,19 @@ const MyRecordList = ({ title, urlLink, recordList, type }: MyRecordListProps) =
     <S.BorderContainer>
       <S.BorderTitleSection>
         <h3>{title}</h3>
-        <Link
+        {/* <Link
           href={urlLink}
           title={title}
         >
           더 보기
-        </Link>
+        </Link> */}
+        <span
+          onClick={() => {
+            toast({ title: "준비 중인 기능이에요!", duration: 2000 });
+          }}
+        >
+          더보기
+        </span>
       </S.BorderTitleSection>
       <S.BorderContentSection>
         <S.BorderContentListWrapper>

--- a/src/app/user/[id]/components/UserProfileInfo/UserProfileInfo.styles.ts
+++ b/src/app/user/[id]/components/UserProfileInfo/UserProfileInfo.styles.ts
@@ -4,18 +4,22 @@ import styled from "styled-components";
 interface UserInfoProfileImageProps {
   width: number;
   height: number;
-  $profile: string | null;
 }
 
 export const UserInfoProfile = styled.div`
   text-align: center;
 `;
 
+export const UploadContainer = styled.div`
+  overflow: hidden;
+  position: absolute;
+  border-radius: 50%;
+`;
+
 export const UserInfoProfileImage = styled.div<UserInfoProfileImageProps>`
   position: relative;
   width: ${(props) => `${props.width}px`};
   height: ${(props) => `${props.height}px`};
-  background-image: ${(props) => `url(${props.$profile})`};
   background-position: center;
   background-size: cover;
   background-repeat: no-repeat;

--- a/src/app/user/[id]/components/UserProfileInfo/UserProfileInfo.tsx
+++ b/src/app/user/[id]/components/UserProfileInfo/UserProfileInfo.tsx
@@ -6,6 +6,11 @@ import { useUI } from "@/components/uiContext/UiContext";
 import userProfile from "@/assets/userProfile.svg";
 import Camera from "@/components/icons/Camera";
 import * as S from "./UserProfileInfo.styles";
+import useImageUpload from "@/lib/hooks/useImageUpload";
+import InputUpload from "@/components/InputUpload/InputUpload";
+import { useMutation } from "@tanstack/react-query";
+import { changeProfileImage } from "@/lib/api/User/client";
+import { USER_KEY } from "@/lib/api/queryKeys";
 
 interface UserInfoProfileProps {
   profileImage: string | null;
@@ -21,39 +26,50 @@ const UserInfoProfile = ({
   height = 120,
 }: UserInfoProfileProps) => {
   const [profile, setProfile] = useState(profileImage);
-  const { openModal, setModalView, closeModal } = useUI();
 
-  const handlePropfileEdit = () => {
-    setModalView("PROFILE_EDIT_VIEW");
-    openModal({
-      onClickAccept: (profileImage: string | null) => {
-        setProfile(profileImage);
-        closeModal();
-      },
-    });
-  };
+  const uploadImageMutation = useMutation({
+    mutationKey: [USER_KEY.UPLOAD_IMAGE],
+    mutationFn: ({ image }: { image: File }) => changeProfileImage({ image }),
+  });
 
   return (
     <S.UserInfoProfile>
       <S.UserInfoProfileImage
         width={width}
         height={height}
-        $profile={profile}
-        onClick={handlePropfileEdit}
       >
-        {!profile && (
-          <Image
-            src={profile ? profile : userProfile}
-            alt={profileName}
-            width={width}
-            height={height}
-            priority
-          />
-        )}
+        <S.UploadContainer>
+          <InputUpload
+            isPreview={false}
+            updateFile={(image: File | null) => {
+              if (image)
+                uploadImageMutation.mutate(
+                  { image },
+                  {
+                    onSuccess: () => {
+                      console.log("completed");
+                      setProfile(URL.createObjectURL(image));
+                    },
+                  },
+                );
+            }}
+          >
+            <Image
+              src={profile ? profile : userProfile}
+              alt={" "}
+              width={width}
+              height={height}
+              style={{ borderRadius: "50%", width: "120px", height: "120px" }}
+              priority
+            />
+          </InputUpload>
+        </S.UploadContainer>
+
         <S.CameraIconLayout>
           <Camera />
         </S.CameraIconLayout>
       </S.UserInfoProfileImage>
+
       <S.UserInfoProfileText>
         <strong>{profileName}</strong>
       </S.UserInfoProfileText>

--- a/src/app/user/[id]/components/UserProfileInfo/UserProfileInfo.tsx
+++ b/src/app/user/[id]/components/UserProfileInfo/UserProfileInfo.tsx
@@ -11,6 +11,8 @@ import InputUpload from "@/components/InputUpload/InputUpload";
 import { useMutation } from "@tanstack/react-query";
 import { changeProfileImage } from "@/lib/api/User/client";
 import { USER_KEY } from "@/lib/api/queryKeys";
+import { useToast } from "@/components/ShadcnUi/ui/useToast";
+import { ToastAction } from "@/components/ShadcnUi/ui/toast";
 
 interface UserInfoProfileProps {
   profileImage: string | null;
@@ -26,6 +28,7 @@ const UserInfoProfile = ({
   height = 120,
 }: UserInfoProfileProps) => {
   const [profile, setProfile] = useState(profileImage);
+  const { toast } = useToast();
 
   const uploadImageMutation = useMutation({
     mutationKey: [USER_KEY.UPLOAD_IMAGE],
@@ -47,7 +50,10 @@ const UserInfoProfile = ({
                   { image },
                   {
                     onSuccess: () => {
-                      console.log("completed");
+                      toast({
+                        title: "프로필 사진이 성공적으로 등록되었어요!",
+                        duration: 2000,
+                      });
                       setProfile(URL.createObjectURL(image));
                     },
                   },
@@ -59,7 +65,12 @@ const UserInfoProfile = ({
               alt={" "}
               width={width}
               height={height}
-              style={{ borderRadius: "50%", width: "120px", height: "120px" }}
+              style={{
+                borderRadius: "50%",
+                width: "120px",
+                height: "120px",
+                backgroundColor: "white",
+              }}
               priority
             />
           </InputUpload>

--- a/src/components/ShadcnUi/ui/toast.tsx
+++ b/src/components/ShadcnUi/ui/toast.tsx
@@ -1,13 +1,13 @@
 "use client";
 
-import * as React from "react"
-import * as ToastPrimitives from "@radix-ui/react-toast"
-import { cva, type VariantProps } from "class-variance-authority"
-import { X } from "lucide-react"
+import * as React from "react";
+import * as ToastPrimitives from "@radix-ui/react-toast";
+import { cva, type VariantProps } from "class-variance-authority";
+import { X } from "lucide-react";
 
-import { cn } from "@/utils/ShadcnUi"
+import { cn } from "@/utils/ShadcnUi";
 
-const ToastProvider = ToastPrimitives.Provider
+const ToastProvider = ToastPrimitives.Provider;
 
 const ToastViewport = React.forwardRef<
   React.ElementRef<typeof ToastPrimitives.Viewport>,
@@ -17,12 +17,12 @@ const ToastViewport = React.forwardRef<
     ref={ref}
     className={cn(
       "fixed top-0 z-[100] flex max-h-screen w-full flex-col-reverse p-4 sm:bottom-0 sm:right-0 sm:top-auto sm:flex-col md:max-w-[420px]",
-      className
+      className,
     )}
     {...props}
   />
-))
-ToastViewport.displayName = ToastPrimitives.Viewport.displayName
+));
+ToastViewport.displayName = ToastPrimitives.Viewport.displayName;
 
 const toastVariants = cva(
   "group pointer-events-auto relative flex w-full items-center justify-between space-x-4 overflow-hidden rounded-md border p-6 pr-8 shadow-lg transition-all data-[swipe=cancel]:translate-x-0 data-[swipe=end]:translate-x-[var(--radix-toast-swipe-end-x)] data-[swipe=move]:translate-x-[var(--radix-toast-swipe-move-x)] data-[swipe=move]:transition-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[swipe=end]:animate-out data-[state=closed]:fade-out-80 data-[state=closed]:slide-out-to-right-full data-[state=open]:slide-in-from-top-full data-[state=open]:sm:slide-in-from-bottom-full",
@@ -37,13 +37,12 @@ const toastVariants = cva(
     defaultVariants: {
       variant: "default",
     },
-  }
-)
+  },
+);
 
 const Toast = React.forwardRef<
   React.ElementRef<typeof ToastPrimitives.Root>,
-  React.ComponentPropsWithoutRef<typeof ToastPrimitives.Root> &
-    VariantProps<typeof toastVariants>
+  React.ComponentPropsWithoutRef<typeof ToastPrimitives.Root> & VariantProps<typeof toastVariants>
 >(({ className, variant, ...props }, ref) => {
   return (
     <ToastPrimitives.Root
@@ -51,9 +50,9 @@ const Toast = React.forwardRef<
       className={cn(toastVariants({ variant }), className)}
       {...props}
     />
-  )
-})
-Toast.displayName = ToastPrimitives.Root.displayName
+  );
+});
+Toast.displayName = ToastPrimitives.Root.displayName;
 
 const ToastAction = React.forwardRef<
   React.ElementRef<typeof ToastPrimitives.Action>,
@@ -62,13 +61,13 @@ const ToastAction = React.forwardRef<
   <ToastPrimitives.Action
     ref={ref}
     className={cn(
-      "inline-flex h-8 shrink-0 items-center justify-center rounded-md border bg-transparent px-3 text-sm font-medium ring-offset-background transition-colors hover:bg-secondary focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 group-[.destructive]:border-muted/40 group-[.destructive]:hover:border-destructive/30 group-[.destructive]:hover:bg-destructive group-[.destructive]:hover:text-destructive-foreground group-[.destructive]:focus:ring-destructive",
-      className
+      "inline-flex h-8 shrink-0 items-center justify-center rounded-md border bg-green_100 px-3 text-sm font-medium ring-offset-background transition-colors hover:bg-secondary focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 group-[.destructive]:border-muted/40 group-[.destructive]:hover:border-destructive/30 group-[.destructive]:hover:bg-destructive group-[.destructive]:hover:text-destructive-foreground group-[.destructive]:focus:ring-destructive",
+      className,
     )}
     {...props}
   />
-))
-ToastAction.displayName = ToastPrimitives.Action.displayName
+));
+ToastAction.displayName = ToastPrimitives.Action.displayName;
 
 const ToastClose = React.forwardRef<
   React.ElementRef<typeof ToastPrimitives.Close>,
@@ -78,15 +77,15 @@ const ToastClose = React.forwardRef<
     ref={ref}
     className={cn(
       "absolute right-2 top-2 rounded-md p-1 text-foreground/50 opacity-0 transition-opacity hover:text-foreground focus:opacity-100 focus:outline-none focus:ring-2 group-hover:opacity-100 group-[.destructive]:text-red-300 group-[.destructive]:hover:text-red-50 group-[.destructive]:focus:ring-red-400 group-[.destructive]:focus:ring-offset-red-600",
-      className
+      className,
     )}
     toast-close=""
     {...props}
   >
     <X className="h-4 w-4" />
   </ToastPrimitives.Close>
-))
-ToastClose.displayName = ToastPrimitives.Close.displayName
+));
+ToastClose.displayName = ToastPrimitives.Close.displayName;
 
 const ToastTitle = React.forwardRef<
   React.ElementRef<typeof ToastPrimitives.Title>,
@@ -97,8 +96,8 @@ const ToastTitle = React.forwardRef<
     className={cn("text-sm font-semibold", className)}
     {...props}
   />
-))
-ToastTitle.displayName = ToastPrimitives.Title.displayName
+));
+ToastTitle.displayName = ToastPrimitives.Title.displayName;
 
 const ToastDescription = React.forwardRef<
   React.ElementRef<typeof ToastPrimitives.Description>,
@@ -109,12 +108,12 @@ const ToastDescription = React.forwardRef<
     className={cn("text-sm opacity-90", className)}
     {...props}
   />
-))
-ToastDescription.displayName = ToastPrimitives.Description.displayName
+));
+ToastDescription.displayName = ToastPrimitives.Description.displayName;
 
-type ToastProps = React.ComponentPropsWithoutRef<typeof Toast>
+type ToastProps = React.ComponentPropsWithoutRef<typeof Toast>;
 
-type ToastActionElement = React.ReactElement<typeof ToastAction>
+type ToastActionElement = React.ReactElement<typeof ToastAction>;
 
 export {
   type ToastProps,
@@ -126,4 +125,4 @@ export {
   ToastDescription,
   ToastClose,
   ToastAction,
-}
+};

--- a/src/components/navigators/BottomNavigator/BottomNavigator.styles.ts
+++ b/src/components/navigators/BottomNavigator/BottomNavigator.styles.ts
@@ -13,7 +13,7 @@ export const BottomNavContainer = styled.nav`
   padding: ${CONTAINER.PADDING_HORIZONTAL}rem;
   background-color: ${({ theme }) => theme.background_color};
   border-top: ${BORDER.TINE_WIDTH}px solid ${(props) => props.theme.transparent_10};
-  align-items: center;
+  align-items: start;
   z-index: ${Z_INDEX.NAVIGATOR};
 `;
 

--- a/src/lib/api/User/client.ts
+++ b/src/lib/api/User/client.ts
@@ -53,3 +53,10 @@ export const postEditUser = async (newUserData: MeResponse) => {
 export const patchIsPublic = async () => {
   return PATCH({ endPoint: USER.TOGGLE_PUBLIC, auth: true });
 };
+
+export const changeProfileImage = async ({ image }: { image: File }) => {
+  const formData = new FormData();
+  formData.append("profileImg", image);
+
+  return await PUT({ endPoint: USER.UPLOAD_IMAGE, data: formData, auth: true });
+};

--- a/src/lib/api/endPoints.ts
+++ b/src/lib/api/endPoints.ts
@@ -15,6 +15,7 @@ export const USER = {
   EDIT_USER: "/api/v1/users",
   TOGGLE_PUBLIC: "/api/v1/users/is-public",
   PROFILE: "/api/v1/users",
+  UPLOAD_IMAGE: "/api/v1/users/profiles",
 };
 
 export const MASIL = {

--- a/src/lib/api/queryKeys.ts
+++ b/src/lib/api/queryKeys.ts
@@ -14,6 +14,7 @@ export const USER_KEY = {
   EDIT_USER: "user_edit",
   TOGGLE_PUBLIC: "toggle_public",
   ME: "get_me",
+  UPLOAD_IMAGE: "upload_image",
 };
 
 export const MASIL_KEY = {

--- a/src/styles/theme.ts
+++ b/src/styles/theme.ts
@@ -103,7 +103,7 @@ export const CONTAINER = {
   MOBILEABLE_VERTICAL_SPACE: "h-[100%] sm:h-screen",
 };
 
-export const NAV_HEIGHT: number = 6; // rem
+export const NAV_HEIGHT: number = 9; // rem
 
 export const MODAL = {
   VERTICAL_PADDING: 3, // rem


### PR DESCRIPTION
## 🔗 이슈 링크
<!-- 해당 PR과 연관된 이슈 링크(#)를 기재해주세요 -->
- #220 


https://github.com/Team-SilverTown/Team-SilverTown-MasilGasil-FE/assets/95916813/5e5491ad-c95a-4687-b084-6b16bb8369bf



## 💡 핵심 구현 사항
<!-- 문제를 해결하면서 주요하게 변경된 사항들을 "스크린샷"과 함께 설명해주세요 -->
- 프로필 사진 변경 API를 구현하였습니다.
- HTTP 500 에러 발생하는 현상을 해결하였습니다. server-side 컴포넌트 내 background-image에 $src를 전달해서 발생하는 문제였습니다.
- 변경 완료 시 Toast가 출력됩니다.
- 현재 개발 중인 더보기 버튼 클릭 시도 Toast가 출력되게 하였습니다.


## ➕ 추가 작업 사항
<!-- 주 Task 이외의 작업한 변경 사항  -->
- 산책 기록 버튼과, 하단 네비게이터의 패딩값을 조금 손봤습니다!
