### PR TITLE
[Feat] PostView 페이지 (Mate API 추가)

### DIFF
--- a/src/app/home/api/fetchAirQuality.ts
+++ b/src/app/home/api/fetchAirQuality.ts
@@ -1,6 +1,8 @@
+"use server";
+
 const fetchAirQuality = async (stationName: string) => {
-  const AIR_QUALITY_URL = process.env.NEXT_PUBLIC_AIR_QUALITY_URL;
-  const SERVICE_KEY = process.env.NEXT_PUBLIC_SERVICE_KEY;
+  const AIR_QUALITY_URL = process.env.AIR_QUALITY_URL;
+  const SERVICE_KEY = process.env.SERVICE_KEY;
 
   // 공공 데이터 포털에서 발급받은 API 키
   const URL = `${AIR_QUALITY_URL}?stationName=${encodeURIComponent(stationName)}&dataTerm=DAILY&pageNo=1&numOfRows=1&returnType=json&serviceKey=${SERVICE_KEY}`;

--- a/src/app/home/api/fetchNearbyStation.ts
+++ b/src/app/home/api/fetchNearbyStation.ts
@@ -1,3 +1,5 @@
+"use server";
+
 import { WeatherType, PrecipitationType } from "../Home.types";
 import fetchWeatherForecast from "./fetchWeatherForecast";
 import fetchAirQuality from "./fetchAirQuality";
@@ -44,8 +46,8 @@ const fetchNearbyStation = async ({
     };
   }
 
-  const NEAR_BY_STATION_URL = process.env.NEXT_PUBLIC_NEAR_BY_STATION_URL;
-  const SERVICE_KEY = process.env.NEXT_PUBLIC_SERVICE_KEY;
+  const NEAR_BY_STATION_URL = process.env.NEAR_BY_STATION_URL;
+  const SERVICE_KEY = process.env.SERVICE_KEY;
 
   try {
     if (!SERVICE_KEY) {

--- a/src/app/home/api/fetchWeatherForecast.ts
+++ b/src/app/home/api/fetchWeatherForecast.ts
@@ -1,3 +1,5 @@
+"use server";
+
 import { PrecipitationType, WeatherType } from "../Home.types";
 import convertLatLonToGrid from "../utils/convertLatLonToGrid";
 import getCurrentDateTime from "../utils/getCurrentDateTime";
@@ -29,8 +31,8 @@ const fetchWeatherForecast = async ({ lat, lng }: LocationType): Promise<APIResp
 
   const coords = convertLatLonToGrid("toXY", lat, lng);
 
-  const WEATHER_URL = process.env.NEXT_PUBLIC_WEATHER_URL;
-  const SERVICE_KEY = process.env.NEXT_PUBLIC_SERVICE_KEY;
+  const WEATHER_URL = process.env.WEATHER_URL;
+  const SERVICE_KEY = process.env.SERVICE_KEY;
 
   if (!WEATHER_URL) {
     throw new Error("기본 URL이 존재하지 않습니다.");

--- a/src/app/log/[id]/Log.styles.ts
+++ b/src/app/log/[id]/Log.styles.ts
@@ -5,6 +5,8 @@ export const LogContainer = styled.section`
   position: relative;
   height: 100%;
   min-height: 100vh;
+  transform: scale(1);
+  user-select: none;
 `;
 
 export const LogContentLayout = styled.section`

--- a/src/app/post/[id]/Post.controller.tsx
+++ b/src/app/post/[id]/Post.controller.tsx
@@ -5,13 +5,15 @@ import PostView from "./Post.view";
 import { PostTabType } from "./Post.types";
 import useMasilMapStore from "@/components/MasilMap/store/useMasilMapStore";
 import { PostDetailResponse } from "@/types/Response/Post";
+import { MateDetailResponse } from "@/types/Response";
 
 interface PostControllerProps {
   postId: string;
   postData: PostDetailResponse;
+  mateData: MateDetailResponse;
 }
 
-const PostController = ({ postId, postData }: PostControllerProps) => {
+const PostController = ({ postId, postData, mateData }: PostControllerProps) => {
   const {
     tabIndex,
     setTabIndex,
@@ -22,7 +24,6 @@ const PostController = ({ postId, postData }: PostControllerProps) => {
     baseLocation,
     userInfo,
     userId,
-    mateData,
   } = usePostModel({ postData });
   const { setIsOutCenter } = useMasilMapStore();
 

--- a/src/app/post/[id]/Post.controller.tsx
+++ b/src/app/post/[id]/Post.controller.tsx
@@ -5,12 +5,12 @@ import PostView from "./Post.view";
 import { PostTabType } from "./Post.types";
 import useMasilMapStore from "@/components/MasilMap/store/useMasilMapStore";
 import { PostDetailResponse } from "@/types/Response/Post";
-import { MateDetailResponse } from "@/types/Response";
+import { MateDetailListResponse } from "@/types/Response";
 
 interface PostControllerProps {
   postId: string;
   postData: PostDetailResponse;
-  mateData: MateDetailResponse;
+  mateData: MateDetailListResponse;
 }
 
 const PostController = ({ postId, postData, mateData }: PostControllerProps) => {

--- a/src/app/post/[id]/Post.model.ts
+++ b/src/app/post/[id]/Post.model.ts
@@ -7,7 +7,6 @@ import calculatePathCenter from "@/lib/utils/calculatePathCenter";
 import { GeoPosition } from "@/types/OriginDataType";
 import { PostTabType } from "./Post.types";
 import useMeStore from "@/stores/useMeStore";
-import { MATE_DUMMY_DATA } from "./Post.constants";
 import { PostDetailResponse } from "@/types/Response/Post";
 
 interface usePostModelProp {
@@ -46,7 +45,6 @@ const usePostModel = ({ postData }: usePostModelProp) => {
     baseLocation,
     userInfo,
     userId,
-    mateData: MATE_DUMMY_DATA.contents,
   };
 };
 

--- a/src/app/post/[id]/Post.styles.ts
+++ b/src/app/post/[id]/Post.styles.ts
@@ -5,7 +5,7 @@ export const PostContainer = styled.section`
   position: relative;
   height: 100%;
   min-height: 100vh;
-
+  transform: scale(1);
   user-select: none;
 `;
 

--- a/src/app/post/[id]/Post.types.ts
+++ b/src/app/post/[id]/Post.types.ts
@@ -3,20 +3,3 @@ export enum PostTabType {
   Pin = 1,
   Mate = 2,
 }
-
-export interface MateDummyType {
-  isEmpty: boolean;
-  contents: MateDummyContents[];
-  nextCursor: string | null;
-}
-
-export interface MateDummyContents {
-  id: number;
-  title: string;
-  gatheringAt: string;
-  status: "OPEN" | "CLOSED";
-  capacity: number;
-  authorId: number;
-  authorNickname: string;
-  authorProfileUrl: string | null;
-}

--- a/src/app/post/[id]/Post.view.tsx
+++ b/src/app/post/[id]/Post.view.tsx
@@ -2,8 +2,8 @@ import { TopNavigator } from "@/components/navigators/TopNavigator";
 import { GoBackButton } from "@/components/navigators/TopNavigator/components";
 import * as S from "./Post.styles";
 import { TAB_CONTENTS } from "./Post.constants";
-import { MateDummyContents, PostTabType } from "./Post.types";
-import { UserInfoType } from "@/types/Response";
+import { PostTabType } from "./Post.types";
+import { MateDetailResponse, UserInfoType } from "@/types/Response";
 import { GeoPosition } from "@/types/OriginDataType";
 import Theme, { FONT_SIZE, FONT_WEIGHT } from "@/styles/theme";
 import { Button, Tab } from "@/components";
@@ -26,7 +26,7 @@ interface PostViewProps {
   handleCurrentPinIndex: (index: number) => void;
   handleClickCenter: () => void;
   handleClickTab: (index: number) => void;
-  mateData: MateDummyContents[];
+  mateData: MateDetailResponse;
 }
 
 const PostView = ({

--- a/src/app/post/[id]/Post.view.tsx
+++ b/src/app/post/[id]/Post.view.tsx
@@ -88,33 +88,29 @@ const PostView = ({
             )}
             {tabIndex === PostTabType.Mate && <PostMate mateData={mateData} />}
 
-            {tabIndex !== PostTabType.Mate && (
-              <Link
-                href={`/log/record?postId=${postId}`}
-                // href={
-                //   tabIndex === PostTabType.Mate
-                //     ? `/mate/create?lat=${firstLat}&lng=${firstLng}`
-                //     : `/log/record?postId=${postId}`
-                // }
+            <Link
+              href={
+                tabIndex === PostTabType.Mate
+                  ? `/mate/create?postId=${postId}&lat=${firstLat}&lng=${firstLng}`
+                  : `/log/record?postId=${postId}`
+              }
+            >
+              <Button
+                width="calc(100% - 4rem)"
+                textColor={Theme.lightTheme.white}
+                buttonColor={Theme.lightTheme.green_500}
+                style={{
+                  position: "fixed",
+                  left: "50%",
+                  bottom: "9rem",
+                  transform: "translateX(-50%)",
+                  fontSize: `${FONT_SIZE.LARGE}`,
+                  fontWeight: `${FONT_WEIGHT.BOLD}`,
+                }}
               >
-                <Button
-                  width="calc(100% - 4rem)"
-                  textColor={Theme.lightTheme.white}
-                  buttonColor={Theme.lightTheme.green_500}
-                  style={{
-                    position: "fixed",
-                    left: "50%",
-                    bottom: "9rem",
-                    transform: "translateX(-50%)",
-                    fontSize: `${FONT_SIZE.LARGE}`,
-                    fontWeight: `${FONT_WEIGHT.BOLD}`,
-                  }}
-                >
-                  산책하기
-                  {/* {tabIndex === PostTabType.Mate ? "메이트 모집하기" : "산책하기"} */}
-                </Button>
-              </Link>
-            )}
+                {tabIndex === PostTabType.Mate ? "메이트 모집하기" : "현재 경로로 산책하기"}
+              </Button>
+            </Link>
           </S.PostContentSection>
         </S.PostContentLayout>
       </S.PostContainer>

--- a/src/app/post/[id]/Post.view.tsx
+++ b/src/app/post/[id]/Post.view.tsx
@@ -3,7 +3,7 @@ import { GoBackButton } from "@/components/navigators/TopNavigator/components";
 import * as S from "./Post.styles";
 import { TAB_CONTENTS } from "./Post.constants";
 import { PostTabType } from "./Post.types";
-import { MateDetailResponse, UserInfoType } from "@/types/Response";
+import { MateDetailListResponse, UserInfoType } from "@/types/Response";
 import { GeoPosition } from "@/types/OriginDataType";
 import Theme, { FONT_SIZE, FONT_WEIGHT } from "@/styles/theme";
 import { Button, Tab } from "@/components";
@@ -26,7 +26,7 @@ interface PostViewProps {
   handleCurrentPinIndex: (index: number) => void;
   handleClickCenter: () => void;
   handleClickTab: (index: number) => void;
-  mateData: MateDetailResponse;
+  mateData: MateDetailListResponse;
 }
 
 const PostView = ({
@@ -86,7 +86,7 @@ const PostView = ({
                 handlePinIndex={handleCurrentPinIndex}
               />
             )}
-            {tabIndex === PostTabType.Mate && <PostMate mateData={mateData} />}
+            {tabIndex === PostTabType.Mate && <PostMate mateData={mateData.contents} />}
 
             <Link
               href={

--- a/src/app/post/[id]/components/PostMate/PostMate.styles.ts
+++ b/src/app/post/[id]/components/PostMate/PostMate.styles.ts
@@ -6,3 +6,9 @@ export const PostMateList = styled.ul`
   gap: 1.5rem;
   padding-bottom: 7rem;
 `;
+
+export const PostMateEmptyMessage = styled.div`
+  padding: 3rem 0;
+  text-align: center;
+  color: ${(props) => props.theme.gray_300};
+`;

--- a/src/app/post/[id]/components/PostMate/PostMate.styles.ts
+++ b/src/app/post/[id]/components/PostMate/PostMate.styles.ts
@@ -4,4 +4,5 @@ export const PostMateList = styled.ul`
   display: flex;
   flex-direction: column;
   gap: 1.5rem;
+  padding-bottom: 7rem;
 `;

--- a/src/app/post/[id]/components/PostMate/PostMate.tsx
+++ b/src/app/post/[id]/components/PostMate/PostMate.tsx
@@ -1,34 +1,32 @@
 import Link from "next/link";
-import { MateDummyContents } from "../../Post.types";
 import MateCard from "@/components/MateCard";
 import * as S from "./PostMate.styles";
+import { MateDetailResponse } from "@/types/Response";
 
 interface PostMateProps {
-  mateData: MateDummyContents[];
+  mateData: MateDetailResponse;
 }
 
 const PostMate = ({ mateData }: PostMateProps) => {
+  const { id, authorProfileUrl, authorNickname, title, gatheringAt, capacity, status } = mateData;
+
   return (
     <S.PostMateList>
-      {mateData.map(
-        ({ id, authorProfileUrl, authorNickname, title, gatheringAt, capacity, status }) => (
-          <li key={id}>
-            <Link
-              href={`/mate/${id}`}
-              title={title}
-            >
-              <MateCard
-                profileImage={authorProfileUrl}
-                nickName={authorNickname}
-                title={title}
-                date={gatheringAt}
-                capacity={capacity}
-                status={status}
-              />
-            </Link>
-          </li>
-        ),
-      )}
+      <li>
+        <Link
+          href={`/mate/${id}`}
+          title={title}
+        >
+          <MateCard
+            profileImage={authorProfileUrl}
+            nickName={authorNickname}
+            title={title}
+            date={gatheringAt}
+            capacity={capacity}
+            status={status}
+          />
+        </Link>
+      </li>
     </S.PostMateList>
   );
 };

--- a/src/app/post/[id]/components/PostMate/PostMate.tsx
+++ b/src/app/post/[id]/components/PostMate/PostMate.tsx
@@ -4,30 +4,39 @@ import * as S from "./PostMate.styles";
 import { MateDetailResponse } from "@/types/Response";
 
 interface PostMateProps {
-  mateData: MateDetailResponse;
+  mateData: MateDetailResponse[];
 }
 
 const PostMate = ({ mateData }: PostMateProps) => {
-  const { id, authorProfileUrl, authorNickname, title, gatheringAt, capacity, status } = mateData;
-
   return (
-    <S.PostMateList>
-      <li>
-        <Link
-          href={`/mate/${id}`}
-          title={title}
-        >
-          <MateCard
-            profileImage={authorProfileUrl}
-            nickName={authorNickname}
-            title={title}
-            date={gatheringAt}
-            capacity={capacity}
-            status={status}
-          />
-        </Link>
-      </li>
-    </S.PostMateList>
+    <>
+      {mateData.length > 0 && (
+        <S.PostMateList>
+          {mateData.map(
+            ({ id, title, authorProfileUrl, authorNickname, gatheringAt, capacity, status }) => (
+              <li>
+                <Link
+                  href={`/mate/${id}`}
+                  title={title}
+                >
+                  <MateCard
+                    profileImage={authorProfileUrl}
+                    nickName={authorNickname}
+                    title={title}
+                    date={gatheringAt}
+                    capacity={capacity}
+                    status={status}
+                  />
+                </Link>
+              </li>
+            ),
+          )}
+        </S.PostMateList>
+      )}
+      {mateData.length === 0 && (
+        <S.PostMateEmptyMessage>등록중인 메이트 모집 글이 없습니다.</S.PostMateEmptyMessage>
+      )}
+    </>
   );
 };
 

--- a/src/app/post/[id]/components/PostMate/PostMate.tsx
+++ b/src/app/post/[id]/components/PostMate/PostMate.tsx
@@ -14,7 +14,7 @@ const PostMate = ({ mateData }: PostMateProps) => {
         <S.PostMateList>
           {mateData.map(
             ({ id, title, authorProfileUrl, authorNickname, gatheringAt, capacity, status }) => (
-              <li>
+              <li key={id}>
                 <Link
                   href={`/mate/${id}`}
                   title={title}

--- a/src/app/post/[id]/components/PostPin/PostPin.styles.ts
+++ b/src/app/post/[id]/components/PostPin/PostPin.styles.ts
@@ -11,4 +11,5 @@ export const PostPinContainer = styled.div`
 export const PostPinEmptyMessage = styled.div`
   padding: 3rem 0;
   text-align: center;
+  color: ${(props) => props.theme.gray_300};
 `;

--- a/src/app/post/[id]/page.tsx
+++ b/src/app/post/[id]/page.tsx
@@ -2,6 +2,7 @@ import { getServerSession } from "next-auth";
 import { authOptions } from "@/app/api/auth/[...nextauth]/options";
 import { getPostDetail } from "@/lib/api/Post/server";
 import PostController from "./Post.controller";
+import { getMateDetail } from "@/lib/api/Mate/server";
 
 interface PostDetailProps {
   params: {
@@ -14,8 +15,9 @@ const PostDetail = async ({ params }: PostDetailProps) => {
 
   const session = await getServerSession(authOptions);
   const postData = await getPostDetail(session?.serviceToken!, id);
+  const mateData = await getMateDetail(id);
 
-  if (!postData) {
+  if (!postData || !mateData) {
     return;
   }
 
@@ -23,6 +25,7 @@ const PostDetail = async ({ params }: PostDetailProps) => {
     <PostController
       postId={id}
       postData={postData}
+      mateData={mateData}
     />
   );
 };

--- a/src/app/post/[id]/page.tsx
+++ b/src/app/post/[id]/page.tsx
@@ -2,7 +2,7 @@ import { getServerSession } from "next-auth";
 import { authOptions } from "@/app/api/auth/[...nextauth]/options";
 import { getPostDetail } from "@/lib/api/Post/server";
 import PostController from "./Post.controller";
-import { getMateDetail } from "@/lib/api/Mate/server";
+import { getMateDetailList } from "@/lib/api/Mate/server";
 
 interface PostDetailProps {
   params: {
@@ -15,7 +15,7 @@ const PostDetail = async ({ params }: PostDetailProps) => {
 
   const session = await getServerSession(authOptions);
   const postData = await getPostDetail(session?.serviceToken!, id);
-  const mateData = await getMateDetail(id);
+  const mateData = await getMateDetailList({ postId: Number(id) });
 
   if (!postData || !mateData) {
     return;

--- a/src/app/post/[id]/page.tsx
+++ b/src/app/post/[id]/page.tsx
@@ -3,6 +3,7 @@ import { authOptions } from "@/app/api/auth/[...nextauth]/options";
 import { getPostDetail } from "@/lib/api/Post/server";
 import PostController from "./Post.controller";
 import { getMateDetailList } from "@/lib/api/Mate/server";
+import { redirect } from "next/navigation";
 
 interface PostDetailProps {
   params: {
@@ -18,7 +19,7 @@ const PostDetail = async ({ params }: PostDetailProps) => {
   const mateData = await getMateDetailList({ postId: Number(id) });
 
   if (!postData || !mateData) {
-    return;
+    return redirect("/not-found");
   }
 
   return (

--- a/src/lib/api/Mate/server.ts
+++ b/src/lib/api/Mate/server.ts
@@ -1,10 +1,36 @@
-import { MateDetailResponse } from "@/types/Response";
+import { MateDetailListResponse, MateDetailResponse } from "@/types/Response";
 import { GET } from "../serverRootAPI";
 import { MATE } from "../endPoints";
 
 export async function getMateDetail(id: string) {
   const response = await GET<MateDetailResponse>({
     endPoint: `${MATE.GET_DETAIL}/${id}`,
+  });
+
+  return response;
+}
+
+interface getMateDetailListProps {
+  postId?: number;
+  depth1?: string;
+  depth2?: string;
+  depth3?: string;
+  cursor?: string;
+  size?: number;
+}
+
+export async function getMateDetailList(params: getMateDetailListProps) {
+  const { postId, depth1, depth2, depth3, cursor, size } = params;
+
+  let endPoint = `${MATE.GET_DETAIL}?`;
+
+  if (postId) endPoint += `postId=${postId}&`;
+  if (depth1) endPoint += `depth1=${depth1}&depth2=${depth2}&depth3=${depth3}&`;
+  if (cursor) endPoint += `cursor=${cursor}&`;
+  if (size) endPoint += `size=${size ? size : 10}`;
+
+  const response = await GET<MateDetailListResponse>({
+    endPoint,
   });
 
   return response;

--- a/src/types/Response/mate.ts
+++ b/src/types/Response/mate.ts
@@ -1,5 +1,11 @@
 import { GeoPosition, Participant } from "../OriginDataType";
 
+export interface MateDetailListResponse {
+  isEmpty: boolean;
+  contents: MateDetailResponse[];
+  nextCursor: string | null;
+}
+
 export interface MateDetailResponse {
   id: number;
   postId: number;


### PR DESCRIPTION
## 🔗 이슈 링크
<!-- 해당 PR과 연관된 이슈 링크(#)를 기재해주세요 -->
- #273 


## 💡 핵심 구현 사항
<!-- 문제를 해결하면서 주요하게 변경된 사항들을 "스크린샷"과 함께 설명해주세요 -->
- PostView 페이지에 산책 메이트 탭에 있는 **메이트 모집 리스트를 실제 데이터로 변경**했습니다.


## ➕ 추가 작업 사항
<!-- 주 Task 이외의 작업한 변경 사항  -->
- 기존에 작업한 PostView, LogView 페이지 **`산책하기`** 버튼의 `position: fixed`로 발생하는 문제를 해결했습니다. (dev에는 적용이 되어 있지 않아 발생한 문제 같습니다 !)


## 🤔 테스트 및 검증 && 고민 사항
<!-- 배포에서 체크해봐야 할 부분 -->
<!-- 궁금한 점, 팀원들의 의견이 필요한 부분, 크로스체크가 필요한 부분 등 -->
- 현재 Post에 대한 mate 모집을 중복으로 할 경우에는 mate 리스트를 여러 개 보여줘야 할 것 같습니다 !


## 💬 피드백 반영사항
<!-- 피드백 요청 사항을 리스트로 표시하고 반영 여부를 표시합니다 -->
- 
