### PR TITLE
[Feat] 다른 유저 프로필페이지 접근 구현과 에러 핸들링

### DIFF
--- a/src/app/diary/[id]/components/MonthlyStatistics/MonthlyStatistics.tsx
+++ b/src/app/diary/[id]/components/MonthlyStatistics/MonthlyStatistics.tsx
@@ -27,19 +27,19 @@ const MonthlyStatistics = ({ month, masils }: MonthlyStatisticsProps) => {
               <S.SectionItem>
                 <S.Text>총 거리</S.Text>
                 <S.AccentTitle>
-                  {masils?.totalDistance ? convertMeter(masils?.totalDistance) : "- m"}
+                  {masils?.totalDistance ? convertMeter(masils?.totalDistance) : "0 m"}
                 </S.AccentTitle>
               </S.SectionItem>
               <S.ColDivider />
               <S.SectionItem>
                 <S.Text>산책 횟수</S.Text>
-                <S.AccentTitle>{masils?.totalCounts ? masils?.totalCounts : "- "}회</S.AccentTitle>
+                <S.AccentTitle>{masils?.totalCounts ? masils?.totalCounts : "0 "}회</S.AccentTitle>
               </S.SectionItem>
               <S.ColDivider />
               <S.SectionItem>
                 <S.Text>소모 칼로리</S.Text>
                 <S.AccentTitle>
-                  {masils?.totalCalories ? masils?.totalCalories : "- "}kcal
+                  {masils?.totalCalories ? masils?.totalCalories : "0 "}kcal
                 </S.AccentTitle>
               </S.SectionItem>
             </S.Section>

--- a/src/app/home/components/WalkList/components/WalkListDisplay/WalkListDisplay.styles.ts
+++ b/src/app/home/components/WalkList/components/WalkListDisplay/WalkListDisplay.styles.ts
@@ -4,4 +4,4 @@ export const WalkListContainer = `flex gap-8 overflow-x-auto overflow-y-hidden s
 
 export const HomeWalkListArticle = `flex justify-between items-center mb-4`;
 
-export const NoWalkRecordMessage = `flex justify-center items-center mx-auto my-0 min-h-48`;
+export const NoWalkRecordMessage = `flex justify-center items-center mx-auto my-0 min-h-48 text-gray-300`;

--- a/src/app/home/components/WalkList/components/WalkListDisplay/WalkListDisplay.tsx
+++ b/src/app/home/components/WalkList/components/WalkListDisplay/WalkListDisplay.tsx
@@ -30,7 +30,7 @@ const WalkListDisplay = ({ isEmpty, title, walkList, url }: WalkListItemProps) =
         </Link>
       </article>
       {isEmpty ? (
-        <div className={S.NoWalkRecordMessage}>산책 기록이 존재하지 않습니다.</div>
+        <div className={S.NoWalkRecordMessage}>산책로 목록이 비어있어요</div>
       ) : (
         <ul className={S.WalkListContainer}>
           {walkList.map(({ id, title, content, thumbnailUrl, distance, totalTime, address }) => (

--- a/src/app/user/[id]/MyPage.controller.tsx
+++ b/src/app/user/[id]/MyPage.controller.tsx
@@ -30,7 +30,7 @@ const MyPageController = async ({ userId }: MyPageControllerProps) => {
   const boardLists: MyRecordListType[] = [
     {
       title: "최근에 다녀온 산책",
-      urlLink: "/diary/test",
+      urlLink: `/diary/${userId}`,
       recordList: recentMasils !== undefined ? recentMasils.masils : [],
       type: "Masils",
       isEmpty: recentMasils?.isEmpty,
@@ -44,14 +44,14 @@ const MyPageController = async ({ userId }: MyPageControllerProps) => {
       isEmpty: recentPosts?.isEmpty,
       visible: "Public",
     },
-    {
-      title: "좋아하는 산책로",
-      urlLink: "/more?keyword=my_like&order=latest",
-      recordList: [],
-      type: "Posts",
-      isEmpty: true,
-      visible: "Private",
-    },
+    // {
+    //   title: "좋아하는 산책로",
+    //   urlLink: "/more?keyword=my_like&order=latest",
+    //   recordList: [],
+    //   type: "Posts",
+    //   isEmpty: true,
+    //   visible: "Private",
+    // },
   ];
 
   return (

--- a/src/app/user/[id]/MyPage.controller.tsx
+++ b/src/app/user/[id]/MyPage.controller.tsx
@@ -16,10 +16,16 @@ const MyPageController = async ({ userId }: MyPageControllerProps) => {
   const me = session?.serviceToken ? await getMe(session.serviceToken) : undefined;
   const isMe = me && me.userId == userId;
 
-  console.log(isMe);
   const userProfile = await getUserProfile(userId);
   const recentMasils = await getRecentMasils(session?.serviceToken!);
   const recentPosts = await getRecentPostsById(session?.serviceToken!, userId);
+
+  console.log(userProfile);
+  const isPrivateUser =
+    !isMe &&
+    userProfile?.totalCalories === null &&
+    userProfile?.totalCount === null &&
+    userProfile?.totalDistance === null;
 
   const boardLists: MyRecordListType[] = [
     {
@@ -54,6 +60,7 @@ const MyPageController = async ({ userId }: MyPageControllerProps) => {
       userInfo={userProfile !== undefined ? userProfile : USER_PROFILE_EXCEPTION}
       boardList={boardLists}
       isMe={isMe}
+      isPrivateUser={isPrivateUser}
     />
   );
 };

--- a/src/app/user/[id]/MyPage.controller.tsx
+++ b/src/app/user/[id]/MyPage.controller.tsx
@@ -20,7 +20,6 @@ const MyPageController = async ({ userId }: MyPageControllerProps) => {
   const recentMasils = await getRecentMasils(session?.serviceToken!);
   const recentPosts = await getRecentPostsById(session?.serviceToken!, userId);
 
-  console.log(userProfile);
   const isPrivateUser =
     !isMe &&
     userProfile?.totalCalories === null &&

--- a/src/app/user/[id]/MyPage.styles.ts
+++ b/src/app/user/[id]/MyPage.styles.ts
@@ -25,6 +25,16 @@ export const UserProfileLayout = styled.article`
   }
 `;
 
+export const AlertContainer = styled.div`
+  width: 100%;
+  height: 20%;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+
+  font-size: ${FONT_SIZE.MEDIUM};
+  color: ${(props) => props.theme.gray_300};
+`;
 export const HeaderContainer = styled.div`
   font-size: ${FONT_SIZE.H6};
   font-weight: ${FONT_WEIGHT.SEMIBOLD};

--- a/src/app/user/[id]/MyPage.types.ts
+++ b/src/app/user/[id]/MyPage.types.ts
@@ -24,12 +24,14 @@ interface RecentMasilsType extends RecordType {
   type: "Masils";
   recordList: RecentMasil[];
   isEmpty?: boolean;
+  visible: "Private" | "Public";
 }
 
 interface RecordPostsType extends RecordType {
   type: "Posts";
   recordList: PostListItem[];
   isEmpty?: boolean;
+  visible: "Private" | "Public";
 }
 
 export type MyRecordListType = RecentMasilsType | RecordPostsType;

--- a/src/app/user/[id]/MyPage.view.tsx
+++ b/src/app/user/[id]/MyPage.view.tsx
@@ -11,9 +11,10 @@ interface MyPageViewProps {
   userInfo: ProfileResponse;
   userId: number;
   isMe: boolean | undefined;
+  isPrivateUser: boolean;
 }
 
-const MyPageView = ({ boardList, userInfo, userId, isMe }: MyPageViewProps) => {
+const MyPageView = ({ boardList, userInfo, userId, isMe, isPrivateUser }: MyPageViewProps) => {
   return (
     <>
       <TopNavigator
@@ -28,30 +29,36 @@ const MyPageView = ({ boardList, userInfo, userId, isMe }: MyPageViewProps) => {
             profileName={userInfo.nickname}
             isMe={isMe}
           />
-          <S.HeaderContainer>
-            <h3>{isMe ? "내 통계" : `${userInfo.nickname}님의 통계`}</h3>
-            <Divider style={{ backgroundColor: "#EFEFEF" }} />
-          </S.HeaderContainer>
-          <UserWalkRecord userInfo={userInfo} />
+          {isPrivateUser ? (
+            <S.AlertContainer> 비공개 계정입니다</S.AlertContainer>
+          ) : (
+            <>
+              <S.HeaderContainer>
+                <h3>{isMe ? "내 통계" : `${userInfo.nickname}님의 통계`}</h3>
+                <Divider style={{ backgroundColor: "#EFEFEF" }} />
+              </S.HeaderContainer>
+              <UserWalkRecord userInfo={userInfo} />
 
-          <S.HeaderContainer>
-            <h3>{isMe ? "내 산책" : `${userInfo.nickname}님의 산책`}</h3>
-            <Divider style={{ backgroundColor: "#EFEFEF" }} />
-          </S.HeaderContainer>
-          {boardList.map(({ title, urlLink, recordList, type, visible }, index) => {
-            if (!isMe && visible === "Private") return <></>;
+              <S.HeaderContainer>
+                <h3>{isMe ? "내 산책" : `${userInfo.nickname}님의 산책`}</h3>
+                <Divider style={{ backgroundColor: "#EFEFEF" }} />
+              </S.HeaderContainer>
+              {boardList.map(({ title, urlLink, recordList, type, visible }, index) => {
+                if (!isMe && visible === "Private") return <></>;
 
-            return (
-              <MyRecordList
-                key={index}
-                title={title}
-                urlLink={urlLink}
-                recordList={recordList}
-                type={type}
-                userInfo={userInfo}
-              />
-            );
-          })}
+                return (
+                  <MyRecordList
+                    key={index}
+                    title={title}
+                    urlLink={urlLink}
+                    recordList={recordList}
+                    type={type}
+                    userInfo={userInfo}
+                  />
+                );
+              })}
+            </>
+          )}
         </S.UserProfileLayout>
       </S.UserProfileContainer>
     </>

--- a/src/app/user/[id]/MyPage.view.tsx
+++ b/src/app/user/[id]/MyPage.view.tsx
@@ -10,42 +10,48 @@ interface MyPageViewProps {
   boardList: MyRecordListType[];
   userInfo: ProfileResponse;
   userId: number;
+  isMe: boolean | undefined;
 }
 
-const MyPageView = ({ boardList, userInfo, userId }: MyPageViewProps) => {
+const MyPageView = ({ boardList, userInfo, userId, isMe }: MyPageViewProps) => {
   return (
     <>
       <TopNavigator
         leftChildren={<GoBackButton />}
         title="프로필"
-        rightChildren={<MyPageSetting userId={userId} />}
+        rightChildren={isMe && <MyPageSetting userId={userId} />}
       />
       <S.UserProfileContainer>
         <S.UserProfileLayout className="scrollbar-hide">
           <UserProfileInfo
             profileImage={userInfo.profileImg}
             profileName={userInfo.nickname}
+            isMe={isMe}
           />
           <S.HeaderContainer>
-            <h3>통계</h3>
+            <h3>{isMe ? "내 통계" : `${userInfo.nickname}님의 통계`}</h3>
             <Divider style={{ backgroundColor: "#EFEFEF" }} />
           </S.HeaderContainer>
           <UserWalkRecord userInfo={userInfo} />
 
           <S.HeaderContainer>
-            <h3>산책</h3>
+            <h3>{isMe ? "내 산책" : `${userInfo.nickname}님의 산책`}</h3>
             <Divider style={{ backgroundColor: "#EFEFEF" }} />
           </S.HeaderContainer>
-          {boardList.map(({ title, urlLink, recordList, type }, index) => (
-            <MyRecordList
-              key={index}
-              title={title}
-              urlLink={urlLink}
-              recordList={recordList}
-              type={type}
-              userInfo={userInfo}
-            />
-          ))}
+          {boardList.map(({ title, urlLink, recordList, type, visible }, index) => {
+            if (!isMe && visible === "Private") return <></>;
+
+            return (
+              <MyRecordList
+                key={index}
+                title={title}
+                urlLink={urlLink}
+                recordList={recordList}
+                type={type}
+                userInfo={userInfo}
+              />
+            );
+          })}
         </S.UserProfileLayout>
       </S.UserProfileContainer>
     </>

--- a/src/app/user/[id]/MyPage.view.tsx
+++ b/src/app/user/[id]/MyPage.view.tsx
@@ -29,16 +29,17 @@ const MyPageView = ({ boardList, userInfo, userId, isMe, isPrivateUser }: MyPage
             profileName={userInfo.nickname}
             isMe={isMe}
           />
+
+          <S.HeaderContainer>
+            <h3>{isMe ? "내 통계" : `${userInfo.nickname}님의 통계`}</h3>
+            <Divider style={{ backgroundColor: "#EFEFEF" }} />
+          </S.HeaderContainer>
+          <UserWalkRecord userInfo={userInfo} />
+
           {isPrivateUser ? (
-            <S.AlertContainer> 비공개 계정입니다</S.AlertContainer>
+            <S.AlertContainer>기록이 존재하지 않습니다</S.AlertContainer>
           ) : (
             <>
-              <S.HeaderContainer>
-                <h3>{isMe ? "내 통계" : `${userInfo.nickname}님의 통계`}</h3>
-                <Divider style={{ backgroundColor: "#EFEFEF" }} />
-              </S.HeaderContainer>
-              <UserWalkRecord userInfo={userInfo} />
-
               <S.HeaderContainer>
                 <h3>{isMe ? "내 산책" : `${userInfo.nickname}님의 산책`}</h3>
                 <Divider style={{ backgroundColor: "#EFEFEF" }} />

--- a/src/app/user/[id]/components/MyRecordList/MyRecordList.styles.ts
+++ b/src/app/user/[id]/components/MyRecordList/MyRecordList.styles.ts
@@ -28,11 +28,14 @@ export const BorderTitleSection = styled.div`
 `;
 export const BorderContentSection = styled.div`
   margin-top: 1.2rem;
+  overflow-y: hidden;
 `;
 
 export const BorderContentListWrapper = styled.ul`
   display: flex;
   overflow-x: auto;
+  overflow-y: hidden;
+
   -ms-overflow-style: none; /* IE, Edge */
   scrollbar-width: none; /* Firefox */
 

--- a/src/app/user/[id]/components/MyRecordList/MyRecordList.tsx
+++ b/src/app/user/[id]/components/MyRecordList/MyRecordList.tsx
@@ -62,7 +62,7 @@ const MyRecordList = ({ title, urlLink, recordList, type }: MyRecordListProps) =
               ),
             )}
 
-          {recordList.length === 0 && <S.EmptyAlert>산책로가 비어있어요</S.EmptyAlert>}
+          {recordList.length === 0 && <S.EmptyAlert>산책로 목록이 비어있어요</S.EmptyAlert>}
         </S.BorderContentListWrapper>
       </S.BorderContentSection>
     </S.BorderContainer>

--- a/src/app/user/[id]/components/UserProfileInfo/UserProfileInfo.styles.ts
+++ b/src/app/user/[id]/components/UserProfileInfo/UserProfileInfo.styles.ts
@@ -1,4 +1,4 @@
-import { FONT_SIZE } from "@/styles/theme";
+import { FONT_SIZE, FONT_WEIGHT } from "@/styles/theme";
 import styled from "styled-components";
 
 interface UserInfoProfileImageProps {
@@ -29,6 +29,15 @@ export const UserInfoProfileImage = styled.div<UserInfoProfileImageProps>`
   border-radius: 50%;
 `;
 
+export const IsMeBadge = styled.div`
+  padding: 0.5rem 0.7rem;
+  background-color: ${(props) => props.theme.green_500};
+  color: white;
+  border-radius: 3rem;
+  font-size: ${FONT_SIZE.MINI};
+  font-weight: ${FONT_WEIGHT.BOLD};
+`;
+
 export const CameraIconLayout = styled.div`
   position: absolute;
   bottom: 0;
@@ -45,9 +54,14 @@ export const CameraIconLayout = styled.div`
 `;
 
 export const UserInfoProfileText = styled.div`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  margin: 1.6rem 0 0;
+  gap: 1rem;
+
   strong {
     display: inline-block;
-    margin: 1.6rem 0 0;
     font-size: ${FONT_SIZE.H4};
     color: ${(props) => props.theme.black};
   }

--- a/src/app/user/[id]/components/UserProfileInfo/UserProfileInfo.styles.ts
+++ b/src/app/user/[id]/components/UserProfileInfo/UserProfileInfo.styles.ts
@@ -30,7 +30,7 @@ export const UserInfoProfileImage = styled.div<UserInfoProfileImageProps>`
 `;
 
 export const IsMeBadge = styled.div`
-  padding: 0.5rem 0.7rem;
+  padding: 0.3rem 0.7rem;
   background-color: ${(props) => props.theme.green_500};
   color: white;
   border-radius: 3rem;
@@ -58,7 +58,7 @@ export const UserInfoProfileText = styled.div`
   justify-content: center;
   align-items: center;
   margin: 1.6rem 0 0;
-  gap: 1rem;
+  gap: 0.5rem;
 
   strong {
     display: inline-block;

--- a/src/app/user/[id]/components/UserProfileInfo/UserProfileInfo.tsx
+++ b/src/app/user/[id]/components/UserProfileInfo/UserProfileInfo.tsx
@@ -123,7 +123,8 @@ const UserInfoProfile = ({
       )}
 
       <S.UserInfoProfileText>
-        <strong>{profileName}</strong>
+        <strong>{profileName ? profileName : "null"}</strong>
+        {isMe && <S.IsMeBadge>me</S.IsMeBadge>}
       </S.UserInfoProfileText>
     </S.UserInfoProfile>
   );

--- a/src/app/user/[id]/components/UserProfileInfo/UserProfileInfo.tsx
+++ b/src/app/user/[id]/components/UserProfileInfo/UserProfileInfo.tsx
@@ -19,6 +19,7 @@ interface UserInfoProfileProps {
   profileName: string;
   width?: number;
   height?: number;
+  isMe: boolean | undefined;
 }
 
 const UserInfoProfile = ({
@@ -26,6 +27,7 @@ const UserInfoProfile = ({
   profileName,
   width = 120,
   height = 120,
+  isMe,
 }: UserInfoProfileProps) => {
   const [profile, setProfile] = useState(profileImage);
   const { toast } = useToast();
@@ -39,64 +41,86 @@ const UserInfoProfile = ({
 
   return (
     <S.UserInfoProfile>
-      <S.UserInfoProfileImage
-        width={width}
-        height={height}
-      >
-        <S.UploadContainer>
-          <InputUpload
-            isPreview={false}
-            updateFile={(image: File | null) => {
-              if (!image) {
-                return;
-              }
+      {isMe ? (
+        <S.UserInfoProfileImage
+          width={width}
+          height={height}
+        >
+          <S.UploadContainer>
+            <InputUpload
+              isPreview={false}
+              updateFile={(image: File | null) => {
+                if (!image) {
+                  return;
+                }
 
-              uploadImageMutation.mutate(
-                { image },
-                {
-                  onSuccess: async () => {
-                    toast({
-                      title: "프로필 사진이 성공적으로 등록되었어요!",
-                      duration: 2000,
-                    });
-                    setProfile(URL.createObjectURL(image));
+                uploadImageMutation.mutate(
+                  { image },
+                  {
+                    onSuccess: async () => {
+                      toast({
+                        title: "프로필 사진이 성공적으로 등록되었어요!",
+                        duration: 2000,
+                      });
+                      setProfile(URL.createObjectURL(image));
 
-                    const newMeData = await getMe();
-                    setMe(newMeData);
+                      const newMeData = await getMe();
+                      setMe(newMeData);
+                    },
+                    onError: ({ message }) => {
+                      setModalView("ANIMATION_ALERT_VIEW");
+                      openModal({
+                        message:
+                          message === "50016000"
+                            ? "지원하지 않는 파일 형식입니다."
+                            : "이미지 업로드에 실패했습니다. 다시 시도해주세요.",
+                      });
+                    },
                   },
-                  onError: ({ message }) => {
-                    setModalView("ANIMATION_ALERT_VIEW");
-                    openModal({
-                      message:
-                        message === "50016000"
-                          ? "지원하지 않는 파일 형식입니다."
-                          : "이미지 업로드에 실패했습니다. 다시 시도해주세요.",
-                    });
-                  },
-                },
-              );
-            }}
-          >
-            <Image
-              src={profile ? profile : userProfile}
-              alt={" "}
-              width={width}
-              height={height}
-              style={{
-                borderRadius: "50%",
-                width: "120px",
-                height: "120px",
-                backgroundColor: "white",
+                );
               }}
-              priority
-            />
-          </InputUpload>
-        </S.UploadContainer>
+            >
+              <Image
+                src={profile ? profile : userProfile}
+                alt={" "}
+                width={width}
+                height={height}
+                style={{
+                  borderRadius: "50%",
+                  width: "120px",
+                  height: "120px",
+                  backgroundColor: "white",
+                }}
+                priority
+              />
+            </InputUpload>
+          </S.UploadContainer>
 
-        <S.CameraIconLayout>
-          <Camera />
-        </S.CameraIconLayout>
-      </S.UserInfoProfileImage>
+          <S.CameraIconLayout>
+            <Camera />
+          </S.CameraIconLayout>
+        </S.UserInfoProfileImage>
+      ) : (
+        <S.UserInfoProfileImage
+          width={width}
+          height={height}
+        >
+          <Image
+            src={profile ? profile : userProfile}
+            alt={"user-profile"}
+            width={width}
+            height={height}
+            style={{
+              borderRadius: "50%",
+              width: "120px",
+              height: "120px",
+              backgroundColor: "white",
+              cursor: "default",
+            }}
+            priority
+          />
+        </S.UserInfoProfileImage>
+      )}
 
       <S.UserInfoProfileText>
         <strong>{profileName}</strong>

--- a/src/app/user/[id]/components/UserWalkRecord/UserWalkRecord.tsx
+++ b/src/app/user/[id]/components/UserWalkRecord/UserWalkRecord.tsx
@@ -14,17 +14,17 @@ const UserWalkRecord = ({ userInfo }: UserWalkRecordProps) => {
         <S.Section>
           <S.SectionItem>
             <S.Text>총 거리</S.Text>
-            <S.AccentText>{totalDistance ? convertMeter(totalDistance) : "- m"}</S.AccentText>
+            <S.AccentText>{totalDistance ? convertMeter(totalDistance) : "0 m"}</S.AccentText>
           </S.SectionItem>
           <S.ColDivider />
           <S.SectionItem>
             <S.Text>총 산책 횟수</S.Text>
-            <S.AccentText>{totalCount ? totalCount : "- "}회</S.AccentText>
+            <S.AccentText>{totalCount ? totalCount : "0 "}회</S.AccentText>
           </S.SectionItem>
           <S.ColDivider />
           <S.SectionItem>
             <S.Text>총 소모 칼로리</S.Text>
-            <S.AccentText>{totalCalories ? totalCalories : "- "}kcal</S.AccentText>
+            <S.AccentText>{totalCalories ? totalCalories : "0 "}kcal</S.AccentText>
           </S.SectionItem>
         </S.Section>
       </S.Container>

--- a/src/components/LogDetailCard/LogDetailCard.tsx
+++ b/src/components/LogDetailCard/LogDetailCard.tsx
@@ -27,21 +27,16 @@ const LogDetailCard = ({
   content,
   thumbnailUrl,
   distance,
-  totalDistance,
   totalTime,
   likeCount,
   address,
   isLikeLayout = false,
   isSettingLayout = false,
-  userInfo,
   style,
   onDetailClick,
 }: LogDetailCardProps) => {
   const [isSettingToggle, setIsSetingToggle] = useState(false);
-  // const { isUserInfoCheck, calories } = calculateWalkingCalories({
-  //   userInfo,
-  //   distance: totalDistance,
-  // });
+
   const handleDetailViewClick = () => {
     if (isSettingToggle) {
       setIsSetingToggle(false);
@@ -95,7 +90,6 @@ const LogDetailCard = ({
           <ul className="walkInfo">
             <li>{totalTime}</li>
             <li>{distance}</li>
-            {/* {isUserInfoCheck && <li>{calories}kcal</li>} */}
           </ul>
           {isLikeLayout && (
             <div className={`likeInfo`}>

--- a/src/components/navigators/TopNavigator/TopNavigator.styles.ts
+++ b/src/components/navigators/TopNavigator/TopNavigator.styles.ts
@@ -13,6 +13,7 @@ export const TopNavigatorContainer = styled.nav<any>`
   box-sizing: border-box;
   justify-content: center;
   align-items: center;
+  user-select: none;
 
   background-color: ${(props) => props.theme.background_color};
 `;

--- a/src/lib/api/Post/server.ts
+++ b/src/lib/api/Post/server.ts
@@ -1,5 +1,6 @@
 "use server";
 
+import { redirect } from "next/navigation";
 import { POST } from "../endPoints";
 import { GET } from "../serverRootAPI";
 import { PostDetailResponse, PostListResponse } from "@/types/Response/Post";
@@ -14,10 +15,15 @@ export async function getPostDetail(serviceToken: string, id: string) {
 }
 
 export async function getRecentPostsById(serviceToken: string, userId: number, size?: number) {
-  const response = await GET<PostListResponse>({
-    endPoint: `${POST.GET_DETAIL}?authorId=${userId}&size=${size ? size : 10}`,
-    options: { headers: { Authorization: `Bearer ${serviceToken}` } },
-  });
+  try {
+    const response = await GET<PostListResponse>({
+      endPoint: `${POST.GET_DETAIL}?authorId=${userId}&size=${size ? size : 10}`,
+      options: { headers: { Authorization: `Bearer ${serviceToken}` } },
+    });
 
-  return response;
+    return response;
+  } catch (error) {
+    console.error(error);
+    return redirect(`/not-found`);
+  }
 }

--- a/src/lib/api/User/server.ts
+++ b/src/lib/api/User/server.ts
@@ -4,6 +4,7 @@ import { AuthRequest } from "@/types/Request/User";
 import { USER } from "../endPoints";
 import { GET, POST } from "../serverRootAPI";
 import { MeResponse, ProfileResponse } from "@/types/Response";
+import { redirect } from "next/navigation";
 
 export async function authenticate(data: AuthRequest) {
   const response = await POST<AuthRequest>({
@@ -27,9 +28,13 @@ export async function getMe(serviceToken: string) {
 }
 
 export async function getUserProfile(userId: string | number) {
-  const response = await GET<ProfileResponse>({
-    endPoint: `${USER.PROFILE}/${userId}`,
-  });
-
-  return response;
+  try {
+    const response = await GET<ProfileResponse>({
+      endPoint: `${USER.PROFILE}/${userId}`,
+    });
+    return response;
+  } catch (error) {
+    console.error(error);
+    return redirect(`/not-found`);
+  }
 }

--- a/src/lib/api/masil/server.ts
+++ b/src/lib/api/masil/server.ts
@@ -1,5 +1,6 @@
 "use server";
 
+import { redirect } from "next/navigation";
 import { MASIL } from "../endPoints";
 import { GET } from "../serverRootAPI";
 import { MasilDetailResponse, RecentMasilsResponse } from "@/types/Response";
@@ -14,10 +15,14 @@ export async function getMasilDetail(serviceToken: string, id: string) {
 }
 
 export async function getRecentMasils(serviceToken: string, size?: number) {
-  const response = await GET<RecentMasilsResponse>({
-    endPoint: `${MASIL.GET_RECENT}?size=${size ? size : ""}`,
-    options: { headers: { Authorization: `Bearer ${serviceToken}` } },
-  });
-
-  return response;
+  try {
+    const response = await GET<RecentMasilsResponse>({
+      endPoint: `${MASIL.GET_RECENT}?size=${size ? size : ""}`,
+      options: { headers: { Authorization: `Bearer ${serviceToken}` } },
+    });
+    return response;
+  } catch (error) {
+    console.error(error);
+    return redirect(`/not-found`);
+  }
 }


### PR DESCRIPTION
## 🔗 이슈 링크
<!-- 해당 PR과 연관된 이슈 링크(#)를 기재해주세요 -->
- #260

## 💡 핵심 구현 사항
<!-- 문제를 해결하면서 주요하게 변경된 사항들을 "스크린샷"과 함께 설명해주세요 -->
<img width="1512" alt="스크린샷 2024-03-20 오후 4 38 33" src="https://github.com/Team-SilverTown/Team-SilverTown-MasilGasil-FE/assets/95916813/257e8eac-c0e1-4061-85db-ac6ecce554b0">

- 내 유저 프로필과 다른 유저 프로필 페이지 접근 시의 보여주는 화면을 구분하였습니다.
- 프로필페이지에서 불러오는 서버 API에 대해 에러 핸들링을 구현하였습니다.

## ➕ 추가 작업 사항
<!-- 주 Task 이외의 작업한 변경 사항  -->
- 산책로 목록이 비어있을 때의 멘트를 통일해주었습니다.
- 산책 수치가 존재하지 않을 때 `-`가 아닌 `0`을 표기하도록 변경하였습니다.


## 🤔 테스트 및 검증 && 고민 사항
- 현재 userId를 통해 유저정보를 조회하는 API에서 공개/비공개 여부를 반환하지 않아 `totalCarolies`, `totalDistance`, `totalWalkRecord` 값이 null인 경우 `산책 기록이 존재하지 않습니다`를 표기하도록 하였습니다 (공개, 비공개 여부를 판단할 수 없음) 추후 API 수정되면 반영하도록 하겠습니다.
- try-catch문을 사용해 not-found 페이지로 이동시켰는데, 추후 Next의 `Error.tsx`를 활용해 에러를 처리해줘도 좋을 것 같습니다!

