### PR TITLE
[Fix] auth

### DIFF
--- a/src/app/api/auth/[...nextauth]/options.ts
+++ b/src/app/api/auth/[...nextauth]/options.ts
@@ -71,7 +71,6 @@ export const authOptions: NextAuthOptions = {
           }
 
           const me = await getMe(token.serviceToken as string);
-          console.log("auth", me);
           token.nickname = me?.nickname;
         }
       }

--- a/src/app/api/auth/[...nextauth]/options.ts
+++ b/src/app/api/auth/[...nextauth]/options.ts
@@ -39,6 +39,9 @@ export const authOptions: NextAuthOptions = {
     }),
   ],
   secret: process.env.NEXTAUTH_SECRET,
+  session: {
+    strategy: "jwt",
+  },
   callbacks: {
     async jwt({ token, account, trigger, session }) {
       if (trigger === "update" && session.nickname) {
@@ -76,7 +79,8 @@ export const authOptions: NextAuthOptions = {
     },
     async session({ session, token, trigger, newSession }) {
       if (trigger === "update") {
-        session.serviceToken = newSession.serviceToken;
+        console.log("UPDATE", newSession);
+        newSession.serviceToken && (session.serviceToken = newSession.serviceToken);
         session.nickname = newSession.nickname;
       }
 

--- a/src/app/auth/kakao/Kakao.tsx
+++ b/src/app/auth/kakao/Kakao.tsx
@@ -12,11 +12,11 @@ const Kakao = () => {
 
   const { data: session } = useSession();
 
-  useEffect(() => {
-    if (session) {
-      console.log("kakao (session)", session);
-    }
-  }, [session]);
+  // useEffect(() => {
+  //   if (session) {
+  //     console.log("kakao (session)", session);
+  //   }
+  // }, [session]);
 
   const {
     data: meData,
@@ -29,7 +29,7 @@ const Kakao = () => {
   });
 
   useEffect(() => {
-    console.log("kakao 분기처리 (meData)", meData);
+    console.log("kakao 분기처리 (meData)", meData, session);
 
     if (!meData) return;
 
@@ -40,7 +40,7 @@ const Kakao = () => {
       console.log("가입 유저->홈뷰");
       router.replace("/home");
     }
-  }, [meData]);
+  }, [meData, session]);
 
   if (isLoading)
     return (

--- a/src/app/signup/SignUp.controller.tsx
+++ b/src/app/signup/SignUp.controller.tsx
@@ -54,11 +54,6 @@ const SignUpController = () => {
   const onValid = (data: SignUpFormProps) => {
     showLoadingSpinner();
     signUpMutation.mutate(data);
-    if (signUpMutation.isSuccess) {
-      const { update } = useSession();
-      update({ nickname: data.nickname });
-      router.replace("/home");
-    }
   };
 
   const onInvalid = (errors: FieldErrors) => {

--- a/src/app/signup/SignUp.controller.tsx
+++ b/src/app/signup/SignUp.controller.tsx
@@ -17,6 +17,7 @@ import { GoBackButton, StepSkipButton } from "@/components/navigators/TopNavigat
 import useSignUpModel from "./SignUp.model";
 import SignUpView from "./SignUp.view";
 import { SignUpStep1, SignUpStep2, SignUpStep3, SignUpStep4, SignUpStep5 } from "./sections";
+import { useSession } from "next-auth/react";
 
 export interface SignUpFormProps extends SignUpRequest {}
 
@@ -53,6 +54,11 @@ const SignUpController = () => {
   const onValid = (data: SignUpFormProps) => {
     showLoadingSpinner();
     signUpMutation.mutate(data);
+    if (signUpMutation.isSuccess) {
+      const { update } = useSession();
+      update({ nickname: data.nickname });
+      router.replace("/home");
+    }
   };
 
   const onInvalid = (errors: FieldErrors) => {

--- a/src/app/signup/SignUp.model.tsx
+++ b/src/app/signup/SignUp.model.tsx
@@ -32,6 +32,7 @@ const useSignUpModel = () => {
     onSuccess: () => {
       closeLoadingSpinner();
       setAuth({ isLogIn: true, serviceToken: token! });
+      router.replace("/home");
     },
     onError: (error) => {
       setModalView("ANIMATION_ALERT_VIEW");

--- a/src/app/signup/SignUp.model.tsx
+++ b/src/app/signup/SignUp.model.tsx
@@ -32,7 +32,6 @@ const useSignUpModel = () => {
     onSuccess: () => {
       closeLoadingSpinner();
       setAuth({ isLogIn: true, serviceToken: token! });
-      router.replace("/home");
     },
     onError: (error) => {
       setModalView("ANIMATION_ALERT_VIEW");

--- a/src/lib/AuthLoader.tsx
+++ b/src/lib/AuthLoader.tsx
@@ -2,6 +2,7 @@
 
 import { PropsWithChildren, useEffect } from "react";
 import { useRouter, usePathname } from "next/navigation";
+import { useSession } from "next-auth/react";
 
 import useAuthStore from "@/lib/stores/useAuthStore";
 import useMeStore from "@/lib/stores/useMeStore";
@@ -24,14 +25,21 @@ const AuthLoader = ({
   const { setMe, initMe } = useMeStore();
   const [_, setToken] = useLocalStorage("serviceToken");
 
+  const { data: session, status, update } = useSession();
+
   const redirectInable = pathAbleCheck(REDIRECT_INABLE_PATHS, currentPathName);
 
   useEffect(() => {
+    setToken(serviceToken);
+
+    console.log(serviceToken, me);
+
     if (serviceToken && me && me.nickname) {
       // 인증된 유저인 경우
+      session?.nickname !== me.nickname &&
+        update({ serviceToken: serviceToken, nickname: me.nickname });
       setAuth({ isLogIn: true, serviceToken });
       setMe({ ...me });
-      setToken(serviceToken);
       if (redirectInable) {
         currentPathName === "/"
           ? setTimeout(() => {
@@ -42,10 +50,13 @@ const AuthLoader = ({
     } else if (currentPathName.includes("policy") || currentPathName.includes("auth")) {
       return;
     } else {
+      console.log("authload 인증 실패");
+      console.log(serviceToken, me);
+      console.log("----------------------");
       // 인증 실패, 가인증 유저인 경우
       setAuth({ isLogIn: false, serviceToken: undefined });
       initMe();
-      setToken(null);
+      // setToken(null);
       route.replace("/");
     }
   }, [serviceToken, me]);

--- a/src/lib/AuthLoader.tsx
+++ b/src/lib/AuthLoader.tsx
@@ -32,8 +32,6 @@ const AuthLoader = ({
   useEffect(() => {
     setToken(serviceToken);
 
-    console.log(serviceToken, me);
-
     if (serviceToken && me && me.nickname) {
       // 인증된 유저인 경우
       session?.nickname !== me.nickname &&
@@ -50,9 +48,6 @@ const AuthLoader = ({
     } else if (currentPathName.includes("policy") || currentPathName.includes("auth")) {
       return;
     } else {
-      console.log("authload 인증 실패");
-      console.log(serviceToken, me);
-      console.log("----------------------");
       // 인증 실패, 가인증 유저인 경우
       setAuth({ isLogIn: false, serviceToken: undefined });
       initMe();

--- a/src/lib/AuthLoader.tsx
+++ b/src/lib/AuthLoader.tsx
@@ -25,7 +25,7 @@ const AuthLoader = ({
   const { setMe, initMe } = useMeStore();
   const [_, setToken] = useLocalStorage("serviceToken");
 
-  const { data: session, status, update } = useSession();
+  const { data: session, update } = useSession();
 
   const redirectInable = pathAbleCheck(REDIRECT_INABLE_PATHS, currentPathName);
 

--- a/src/lib/api/User/server.ts
+++ b/src/lib/api/User/server.ts
@@ -53,7 +53,7 @@ export async function getMe(serviceToken: string) {
     });
     return response;
   } catch (error) {
-    console.error("me-error", error);
+    console.error(error);
     return undefined;
   }
 }

--- a/src/lib/api/axios/axiosConfig.ts
+++ b/src/lib/api/axios/axiosConfig.ts
@@ -23,7 +23,6 @@ export const onError = (error: AxiosError) => {
 export const onRequest = (config: InternalAxiosRequestConfig) => {
   const serviceToken = localStorage.getItem("serviceToken");
 
-  console.log(serviceToken);
 
   config.headers.Authorization = `Bearer ${serviceToken}`;
 

--- a/src/lib/api/axios/axiosConfig.ts
+++ b/src/lib/api/axios/axiosConfig.ts
@@ -23,6 +23,8 @@ export const onError = (error: AxiosError) => {
 export const onRequest = (config: InternalAxiosRequestConfig) => {
   const serviceToken = localStorage.getItem("serviceToken");
 
+  console.log(serviceToken);
+
   config.headers.Authorization = `Bearer ${serviceToken}`;
 
   return config;

--- a/src/lib/api/serverRootAPI.ts
+++ b/src/lib/api/serverRootAPI.ts
@@ -1,3 +1,5 @@
+import { cookies } from "next/headers";
+
 export const request = async <T>(url: string, options: RequestInit): Promise<T | undefined> => {
   return fetch(`${process.env.DB_BASE_URL}${url}`, {
     ...options,

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -83,7 +83,6 @@ function applySetCookie(req: NextRequest, res: NextResponse): void {
 
 export async function middleware(request: NextRequest) {
   const currentPath = request.nextUrl.pathname;
-  console.log("middleware catch", currentPath);
 
   // 미들웨어 인터셉트가 필요없는 경우 bypass
   const isBypassPaths = pathAbleCheck(bypassPaths, currentPath);
@@ -110,11 +109,11 @@ export async function middleware(request: NextRequest) {
         // maxAge: 30 * 24 * 60 * 60, // 30 days, or get the previous token's exp
       });
 
-      console.log("after");
-      console.log(
-        await decode({ secret: process.env.NEXTAUTH_SECRET as string, token: newSessionToken }),
-      );
-      console.log("------------------–");
+      // console.log("after");
+      // console.log(
+      //   await decode({ secret: process.env.NEXTAUTH_SECRET as string, token: newSessionToken }),
+      // );
+      // console.log("------------------–");
 
       // 갱신된 쿠키 정보를 브라우저측에서도 인지할 수 있도록 redirect
       const response = NextResponse.redirect(request.url);

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -2,8 +2,9 @@ import { NextRequest, NextResponse } from "next/server";
 import { getToken, encode, decode } from "next-auth/jwt";
 import { pathAbleCheck } from "./lib/utils/pathAbleCheck";
 import { refreshToken } from "./lib/api/User/server";
-import { parseJwt } from "./app/api/auth/[...nextauth]/options";
+import { authOptions, parseJwt } from "./app/api/auth/[...nextauth]/options";
 import { RequestCookies, ResponseCookies } from "next/dist/compiled/@edge-runtime/cookies";
+import { getServerSession } from "next-auth";
 
 export const config = {
   matcher: ["/((?!api|_next/static|_next/image|favicon.ico|masil.ico|fonts|images).*)"],
@@ -132,17 +133,16 @@ export async function middleware(request: NextRequest) {
 
   // 미인증, 가인증 유저인 경우, 보호되는 경로로 접근할 수 없도록 함.
   const protectedPathsAccessInable = pathAbleCheck(protectedPaths, currentPath);
-  if (!token || (!token.nickname && protectedPathsAccessInable)) {
-    console.log("가라", token);
+  if (token && !token.serviceToken && protectedPathsAccessInable) {
     const url = request.nextUrl.clone();
     url.pathname = "/";
 
     if (currentPath !== "/") return NextResponse.redirect(url);
   }
 
-  // 인증된 유저인 경우, 인증 유저는 접근할 수 없는 경로에 대한 블로킹 (유저인증 관련 등F)
+  // 인증된 유저인 경우, 인증 유저는 접근할 수 없는 경로에 대한 블로킹 (유저인증 관련 등)
   const publicPathsAccessInable = pathAbleCheck(publicPaths, currentPath);
-  if (token && token.nickname && publicPathsAccessInable) {
+  if (token && token.serviceToken && token.nickname && publicPathsAccessInable) {
     const url = request.nextUrl.clone();
     url.pathname = "/";
 


### PR DESCRIPTION
## 🔗 이슈 링크
<!-- 해당 PR과 연관된 이슈 링크(#)를 기재해주세요 -->
- 


## 💡 핵심 구현 사항
<!-- 문제를 해결하면서 주요하게 변경된 사항들을 "스크린샷"과 함께 설명해주세요 -->
- 신규 가입 후 회원가입 안되는 문제 해결
   -> 신규 가입 직후 닉네임이 없으므로 클라이언트 인증 로직은 signup으로 리다이렉트를 원하지만
       AuthLoader 에서 우선적으로 토큰을 로컬스토리지에서 해제하는 문제로 인해 리다이렉트가 불가했음.
- 신규 가입 후 로그인 안되는 문제 해결
    -> 미들웨어에서는 사용자의 nickname 을 서버의 세션에서 확인 받아 인증 여부를 확인함.
        이때 로그인 버튼을 통한 액션으로 인한 nextauth 의 콜백 내부에서 서버 세션의 값을 갱신하게됨
        신규 가입 직후에는 nickname 값을 가질 수 없으므로 가인증 유저로 미들웨어는 인식하여 home 등에 접근할 수 없도록 함.
        즉 로그인 버튼을 통한 인증 절차를 거치지 않으면 nickname 을 곧바로 갱신할 수 없는 상태
        - 가입 직후, authloader 를 통한 클라이언트 사이드 인증 시 useSession의 update 함수를 통해 세션을 갱신하려고 했으나 즉시 갱신되지 않는 것으로 확인됨.. (추가 확인 필요)
        
 - 미들웨어에서 닉네임을 확인하지 안도록 하는 방향으로 임시 해결
    해당 방식으로는 비인가된 url 접근을 막기 힘듬...(토큰이 있는지 없는지만 판별..)
    
로그인 로직을 수정해야할 것 같음.
인증이 두 단계에 걸쳐서 진행되어서 발생하는 문제 (OAuth / service logic auth) + nexauth 의 session 갱신이 까다로워서 생기는 문제

 - 앞으로 개선 사항
1. OAuth 를 통해 최초 가입시 카카오의 사용자 닉네임을 기본 닉네임으로 하여 사용자 데이터를 생성함.
2. accessToken 유무 값만으로 접근에 대한 인가 처리 (현재는 불러오는 시점이 다른 두 정보 token 과 nickname 을 사용함..)
   현재는 auth/options 코드에서 확인할 수 있듯 autheticate 이후 getMe 를 통해 인증 여부를 확인함.. 
   해당 로직은 회원 가입 직후 인증 여부를 확인할 수 없는 문제를 발생시킴
3. 사용자 필드의 필수 정보 입력 유무 필드를 통해 가입 화면 유도
4. 가인증/인증 여부를 위해 사용하던 필드등을 단순히 가입 유도를 위한 값으로만 사용하는게 좋아보임.

## ➕ 추가 작업 사항
<!-- 주 Task 이외의 작업한 변경 사항  -->
- 


## 🤔 테스트 및 검증 && 고민 사항
<!-- 배포에서 체크해봐야 할 부분 -->
<!-- 궁금한 점, 팀원들의 의견이 필요한 부분, 크로스체크가 필요한 부분 등 -->
- 


## 💬 피드백 반영사항
<!-- 피드백 요청 사항을 리스트로 표시하고 반영 여부를 표시합니다 -->
- 
