### PR TITLE
[ Refactoring ]  auth 정책 완화

### DIFF
--- a/src/app/explore/sections/ListSection/ListSection.tsx
+++ b/src/app/explore/sections/ListSection/ListSection.tsx
@@ -35,7 +35,7 @@ const ListSection = memo(function List({
     ({ key, index, style }: any) => {
       let content;
 
-      if (data) {
+      if (data && data[index]) {
         const item = data[index];
 
         content = (
@@ -73,10 +73,10 @@ const ListSection = memo(function List({
     return (
       <div
         id={id}
-        className="w-full h-full"
+        className="h-full w-full"
       >
         <div className="flex justify-center">
-          <span className="font-medium text-medium">준비중입니다.</span>
+          <span className="text-medium font-medium">준비중입니다.</span>
         </div>
       </div>
     );
@@ -86,9 +86,9 @@ const ListSection = memo(function List({
     return (
       <div
         id={id}
-        className="w-full h-full overflow-hidden"
+        className="h-full w-full overflow-hidden"
       >
-        <div className="p-4 space-y-8">
+        <div className="space-y-8 p-4">
           <PostCardsSkeleton />
         </div>
       </div>
@@ -105,7 +105,7 @@ const ListSection = memo(function List({
     return (
       <div
         id={id}
-        className="w-full h-full"
+        className="h-full w-full"
       >
         {data && data.length > 0 && (
           <>
@@ -137,13 +137,14 @@ const ListSection = memo(function List({
           </>
         )}
 
-        {data.length <= 0 && (
-          <div className="flex justify-center">
-            <span className="font-medium text-medium text-gray-300">
-              해당 지역에 대한 검색 결과가 없어요
-            </span>
-          </div>
-        )}
+        {!data ||
+          (data.length <= 0 && (
+            <div className="flex justify-center">
+              <span className="text-medium font-medium text-gray-300">
+                해당 지역에 대한 검색 결과가 없어요
+              </span>
+            </div>
+          ))}
       </div>
     );
   }

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -10,7 +10,7 @@ import { NextRequest, NextResponse } from "next/server";
 export const config = {
   matcher: [
     "/((?!api|_next/static|_next/image|favicon.ico|masil.ico|fonts|images).*)",
-    "/home",
+    // "/home",
     "/setting/:path*",
     "/log/record",
     "/diary",
@@ -20,6 +20,10 @@ export const config = {
 
 const bypassPaths = [
   // "/",
+  "/home",
+  "/explore*",
+  "/post*",
+  "/more*",
   "/manifest*",
   "/swe-worker*",
   "/sw.js*",


### PR DESCRIPTION
- home, explore, more, post 에 대해 middleware bypass 지정

## 🔗 이슈 링크
<!-- 해당 PR과 연관된 이슈 링크(#)를 기재해주세요 -->
- 


## 💡 핵심 구현 사항
<!-- 문제를 해결하면서 주요하게 변경된 사항들을 "스크린샷"과 함께 설명해주세요 -->
- middleware 에서 auth 가 필요한 페이지에 대한 정책을 완화 했습니다
- 완화된 페이지 경로는 
   - /home,
   - /explore 
   - /more/:path*
   - /post/:path*
   입니다.
   
- 해당 페이지들에서 요청하는 API 의 bearer 관련 옵션 제거하셔야 합니다.


## ➕ 추가 작업 사항
<!-- 주 Task 이외의 작업한 변경 사항  -->
- 


## 🤔 테스트 및 검증 && 고민 사항
<!-- 배포에서 체크해봐야 할 부분 -->
<!-- 궁금한 점, 팀원들의 의견이 필요한 부분, 크로스체크가 필요한 부분 등 -->
- 


## 💬 피드백 반영사항
<!-- 피드백 요청 사항을 리스트로 표시하고 반영 여부를 표시합니다 -->
- 
